### PR TITLE
Industrial design rework: MI-BOX yellow + charcoal, zero radius

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -14,29 +14,36 @@ function formatDate(dateStr) {
 }
 ---
 
-<div
-  class="relative isolate flex flex-col justify-end overflow-hidden bg-gray-900 px-8 pb-8 pt-80 sm:pt-48 lg:pt-80"
->
-  <img
-    src={getAssetURL(blog_image.id)}
-    alt={blog_image.description || blog_image.title || "Blog Image"}
-    class="absolute inset-0 -z-10 size-full object-cover"
-  />
-  <div
-    class="absolute inset-0 -z-10 bg-gradient-to-t from-gray-900 via-gray-900/40"
-  >
+<article class="card-flush card-hover group relative isolate flex flex-col">
+  <div class="relative aspect-[16/10] overflow-hidden">
+    <img
+      src={getAssetURL(blog_image.id)}
+      alt={blog_image.description || blog_image.title || "Blog Image"}
+      class="absolute inset-0 size-full object-cover transition-transform duration-500 group-hover:scale-105"
+    />
+    <span class="badge absolute left-4 top-4 z-10">Blog</span>
   </div>
-  <div class="absolute inset-0 -z-10 ring-1 ring-inset ring-gray-900/10"></div>
 
-  <div
-    class="flex flex-wrap items-center gap-y-1 overflow-hidden text-sm/6 text-gray-300"
-  >
-    <span class="mr-8">{formatDate(publication_date)}</span>
+  <div class="flex flex-1 flex-col p-6">
+    <span class="text-sm font-medium text-muted">
+      {formatDate(publication_date)}
+    </span>
+    <h3 class="heading-md mt-3 text-xl md:text-2xl">
+      <a
+        href={`/blog/${link}`}
+        class="text-dark transition-colors group-hover:text-primary-dark"
+      >
+        <span class="absolute inset-0"></span>
+        {title}
+      </a>
+    </h3>
+    <span
+      class="mt-5 inline-flex items-center gap-1.5 text-sm font-bold text-dark transition-colors group-hover:text-primary-dark"
+    >
+      Read more
+      <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+        <path d="M5 12h14M13 6l6 6-6 6" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </span>
   </div>
-  <h3 class="mt-3 text-lg/6 font-semibold text-white">
-    <a href={`/blog/${link}`}>
-      <span class="absolute inset-0"></span>
-      {title}
-    </a>
-  </h3>
-</div>
+</article>

--- a/src/components/SingleHero.astro
+++ b/src/components/SingleHero.astro
@@ -4,35 +4,37 @@ import Button from "./ui/Button.astro";
 const { title, bgImage, button, description, mobileImage } = Astro.props;
 ---
 
-<div class="relative py-40 flex justify-center items-center overflow-hidden">
-  <!-- Overlay -->
-  <div class="absolute inset-0 bg-black/30 z-10"></div>
-
+<div class="relative py-32 lg:py-40 flex justify-center items-center overflow-hidden bg-ink">
   <!-- Responsive Image -->
   <picture class="absolute inset-0 w-full h-full">
     {mobileImage && <source media="(max-width: 767px)" srcset={mobileImage} />}
     <img src={bgImage} alt={title} class="w-full h-full object-cover" />
   </picture>
 
+  <!-- Overlay -->
+  <div class="overlay-grad-b z-10"></div>
+
   <!-- Content Container -->
   <div
-    class="custom-container flex justify-center items-center flex-col gap-6 relative z-20"
+    class="custom-container flex justify-center items-center text-center flex-col gap-6 relative z-20"
   >
+    <span class="eyebrow eyebrow-light fade-up">Moving &amp; Storage</span>
     <h1
-      class="text-white lg:text-start text-center lg:text-6xl sm:text-5xl text-4xl fade-up font-bold"
+      class="display text-white fade-up"
     >
       {title}
     </h1>
+    <span class="accent-bar fade-up"></span>
     {
       description && (
-        <p class="text-white text-center lg:text-start lg:text-2xl sm:text-xl text-lg fade-up">
+        <p class="lead text-white/90 max-w-2xl fade-up">
           {description}
         </p>
       )
     }
     {
       button && button.title && (
-        <div class="flex justify-center items-center">
+        <div class="flex justify-center items-center mt-2">
           <Button title={button.title} link={button.link} />
         </div>
       )

--- a/src/components/forms/ColdStorageForm.svelte
+++ b/src/components/forms/ColdStorageForm.svelte
@@ -43,8 +43,8 @@
   }
 </script>
 
-<form id="quote-form" method="POST" onsubmit={handleSubmit}>
-  <h2 class="md:text-3xl text-xl text-black text-center font-bold block">
+<form id="quote-form" method="POST" onsubmit={handleSubmit} class="form-card">
+  <h2 class="heading-md text-center">
     Get My Free Quote
   </h2>
 
@@ -74,15 +74,15 @@
       errors={form.errors.initialDeliveryZip}
     />
 
-    <div>
+    <div class="date-time-field field">
       <label
         for="delivery-date"
-        class="block text-sm font-medium text-gray-900"
+        class="label"
       >
         Delivery Date
       </label>
       <DateInput
-        class="block w-full rounded-md bg-white p-0 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-primary sm:text-sm"
+        class="block w-full border border-line bg-white p-0 text-base text-dark"
         id="delivery-date"
         bind:value={form.deliveryDate}
         max={new Date("2030-12-31")}
@@ -90,7 +90,7 @@
         closeOnSelection
       />
       {#if form.errors?.deliveryDate}
-        <p class="text-red-800">{form.errors.deliveryDate}</p>
+        <p class="form-error">{form.errors.deliveryDate}</p>
       {/if}
     </div>
 
@@ -112,6 +112,7 @@
     </div>
 
     <div
+      class="w-full [&_iframe]:!w-full"
       use:turnstile
       turnstile-sitekey={import.meta.env.PUBLIC_TURNSTILE_SITE_KEY}
       turnstile-theme="light"
@@ -123,13 +124,13 @@
       onturnstile={(e) => (form.cfTurnstileResponse = e.detail.token)}
     ></div>
     {#if form.errors?.cfTurnstileResponse}
-      <p class="text-red-800">{form.errors.cfTurnstileResponse}</p>
+      <p class="form-error">{form.errors.cfTurnstileResponse}</p>
     {/if}
 
     <button
       type="submit"
       disabled={isLoading}
-      class="submit-btn shadow-[0px_4px_8px_0px_#00000040] cursor-pointer"
+      class="submit-btn cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {#if isLoading}
         Submitting...
@@ -162,28 +163,25 @@
 
 <style>
   .submit-btn {
-    background: var(--color-secondary);
+    width: 100%;
+    background: var(--color-primary);
     display: flex;
     gap: 0.5rem;
     justify-content: center;
     align-items: center;
-    border-radius: 0.25rem;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    font-weight: 500;
-    color: #ffffff;
+    border-radius: 0;
+    font-size: 1.05rem;
+    line-height: 1.5rem;
+    font-weight: 800;
+    color: var(--color-dark);
     white-space: nowrap;
-    padding: 0.5rem 1rem;
+    padding: 0.95rem 1.25rem;
+    box-shadow: 0 10px 20px -8px rgba(255, 194, 14, 0.6);
+    transition: all 0.2s ease;
   }
-  @media (min-width: 1024px) {
-    .submit-btn {
-      padding-top: 0.75rem;
-      padding-bottom: 0.75rem;
-      padding-left: 1.25rem;
-      padding-right: 1.25rem;
-      font-size: 1.125rem;
-      line-height: 1.75rem;
-      font-weight: 600;
-    }
+  .submit-btn:hover:not(:disabled) {
+    background: var(--color-primary-dark);
+    transform: translateY(-1px);
+    box-shadow: 0 14px 26px -8px rgba(255, 194, 14, 0.7);
   }
 </style>

--- a/src/components/forms/Input.svelte
+++ b/src/components/forms/Input.svelte
@@ -2,17 +2,17 @@
   let { forId, label, type = 'text', placeholder, value = $bindable(), errors, onblur } = $props()
 </script>
 
-<div>
-  <label for={forId} class="block text-sm/6 font-medium text-gray-900">{label}</label>
+<div class="field">
+  <label for={forId} class="label">{label}</label>
   <input
     {type}
     id={forId}
-    class="block w-full rounded-md bg-white px-3 py-2.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-primary sm:text-sm/6"
+    class="input"
     bind:value
     {placeholder}
     {onblur}
   />
   {#if errors}
-    <p class="text-red-800 text-sm mt-1">{errors}</p>
+    <p class="form-error">{errors}</p>
   {/if}
 </div>

--- a/src/components/forms/QuoteForm.svelte
+++ b/src/components/forms/QuoteForm.svelte
@@ -68,28 +68,28 @@
   }
 </script>
 
-<form id="quote-form" method="POST" onsubmit={handleSubmit}>
-  <h2 class="md:text-3xl text-xl text-center font-bold block">
+<form id="quote-form" method="POST" onsubmit={handleSubmit} class="form-card">
+  <h2 class="heading-md text-center">
     {quoteFormTitle}
   </h2>
-  <div class="flex justify-around items-center my-6 gap-4">
+  <div class="grid grid-cols-3 gap-1.5 my-6 bg-cream p-1.5 ring-1 ring-line">
     <button
       type="button"
-      class={`py-3 px-4 rounded-md flex-1 shadow-[0px_4px_8px_0px_#00000040] transition-colors cursor-pointer ${form.serviceType === "Moving" ? "bg-primary text-white shadow-md" : "bg-gray-200 text-black hover:bg-gray-300"}`}
+      class={`py-2.5 px-2 text-sm font-bold transition-all cursor-pointer ${form.serviceType === "Moving" ? "bg-primary text-dark shadow-md shadow-primary/30" : "bg-transparent text-secondary hover:bg-white hover:text-dark"}`}
       onclick={() => (form.serviceType = "Moving")}
     >
       Moving
     </button>
     <button
       type="button"
-      class={`py-3 px-4 rounded-md shadow-[0px_4px_8px_0px_#00000040] transition-colors cursor-pointer flex-1 ${form.serviceType === "Storage" ? "bg-primary text-white shadow-md" : "bg-gray-200 text-black hover:bg-gray-300"}`}
+      class={`py-2.5 px-2 text-sm font-bold transition-all cursor-pointer ${form.serviceType === "Storage" ? "bg-primary text-dark shadow-md shadow-primary/30" : "bg-transparent text-secondary hover:bg-white hover:text-dark"}`}
       onclick={() => (form.serviceType = "Storage")}
     >
       Storage
     </button>
     <button
       type="button"
-      class={`py-3 px-4 rounded-md shadow-[0px_4px_8px_0px_#00000040] transition-colors cursor-pointer flex-1 ${form.serviceType === "Storage & Moving" ? "bg-primary text-white shadow-md" : "bg-gray-200 text-black hover:bg-gray-300"}`}
+      class={`py-2.5 px-2 text-sm font-bold transition-all cursor-pointer ${form.serviceType === "Storage & Moving" ? "bg-primary text-dark shadow-md shadow-primary/30" : "bg-transparent text-secondary hover:bg-white hover:text-dark"}`}
       onclick={() => (form.serviceType = "Storage & Moving")}
     >
       Both
@@ -97,23 +97,25 @@
   </div>
   <div class="space-y-2">
     {#if form.serviceType === "Storage" || form.serviceType === "Storage & Moving"}
-      <h3 class="italic text-black">
+      <h3 class="text-sm font-semibold text-dark">
         Where would you like to store your container?
       </h3>
-      <button
-        type="button"
-        class={`py-1 px-4 rounded-md transition-colors flex-1 mr-3 ${form.storeItType === "1" ? "bg-primary text-white shadow-md" : "bg-gray-300 shadow text-black cursor-pointer hover:bg-gray-300"}`}
-        onclick={() => (form.storeItType = "1")}
-      >
-        My Location
-      </button>
-      <button
-        type="button"
-        class={`py-1 px-4 rounded-md transition-colors flex-1 ${form.storeItType === "0" ? "bg-primary text-white shadow-md" : "bg-gray-300 shadow text-black cursor-pointer hover:bg-gray-300"}`}
-        onclick={() => (form.storeItType = "0")}
-      >
-        Box Rental Now Location
-      </button>
+      <div class="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          class={`py-2 px-4 text-sm font-semibold transition-colors cursor-pointer border border-line ${form.storeItType === "1" ? "bg-primary text-dark shadow-md shadow-primary/30 border-primary" : "bg-white text-dark hover:bg-cream"}`}
+          onclick={() => (form.storeItType = "1")}
+        >
+          My Location
+        </button>
+        <button
+          type="button"
+          class={`py-2 px-4 text-sm font-semibold transition-colors cursor-pointer border border-line ${form.storeItType === "0" ? "bg-primary text-dark shadow-md shadow-primary/30 border-primary" : "bg-white text-dark hover:bg-cream"}`}
+          onclick={() => (form.storeItType = "0")}
+        >
+          Box Rental Now Location
+        </button>
+      </div>
     {/if}
 
     <div class="flex gap-2">
@@ -140,13 +142,13 @@
         </div>
       {/if}
     </div>
-    <div>
+    <div class="date-time-field field">
       <label
         for="delivery-date"
-        class="block text-sm/6 font-medium text-gray-900">Delivery Date</label
+        class="label">Delivery Date</label
       >
       <DateInput
-        class="block w-full rounded-md bg-white p-0 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-primary sm:text-sm/6"
+        class="block w-full border border-line bg-white p-0 text-base text-dark"
         id="delivery-date"
         bind:value={form.deliveryDate}
         max={new Date("2030-12-31")}
@@ -154,7 +156,7 @@
         closeOnSelection
       />
       {#if form.errors?.deliveryDate}
-        <p class="text-red-800">{form.errors.deliveryDate}</p>
+        <p class="form-error">{form.errors.deliveryDate}</p>
       {/if}
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -173,19 +175,20 @@
         errors={form.errors.phone}
       />
     </div>
-    <div>
-      <label for="promo-code" class="block text-sm/6 font-medium text-gray-900"
+    <div class="field">
+      <label for="promo-code" class="label"
         >Promo Code</label
       >
       <input
         id="promo-code"
         type="text"
-        class="block w-full rounded-md bg-gray-100 p-2 text-base text-gray-900"
+        class="input bg-surface"
         bind:value={form.promoCode}
         tabindex="-1"
       />
     </div>
     <div
+      class="w-full [&_iframe]:!w-full"
       use:turnstile
       turnstile-sitekey={TURNSTILE_SITE_KEY}
       turnstile-theme="light"
@@ -197,12 +200,12 @@
       onturnstile={(e) => (form.cfTurnstileResponse = e.detail.token)}
     ></div>
     {#if form.errors?.cfTurnstileResponse}
-      <p class="text-red-800">{form.errors.cfTurnstileResponse}</p>
+      <p class="form-error">{form.errors.cfTurnstileResponse}</p>
     {/if}
     <button
       type="submit"
       disabled={isLoading || hasZipError}
-      class="submit-btn shadow-[0px_4px_8px_0px_#00000040] cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+      class="submit-btn cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {#if isLoading}
         Submitting...
@@ -235,28 +238,25 @@
 
 <style>
   .submit-btn {
-    background: var(--color-secondary);
+    width: 100%;
+    background: var(--color-primary);
     display: flex;
     gap: 0.5rem;
     justify-content: center;
     align-items: center;
-    border-radius: 0.25rem;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    font-weight: 500;
-    color: #ffffff;
+    border-radius: 0;
+    font-size: 1.05rem;
+    line-height: 1.5rem;
+    font-weight: 800;
+    color: var(--color-dark);
     white-space: nowrap;
-    padding: 0.5rem 1rem;
+    padding: 0.95rem 1.25rem;
+    box-shadow: 0 10px 20px -8px rgba(255, 194, 14, 0.6);
+    transition: all 0.2s ease;
   }
-  @media (min-width: 1024px) {
-    .submit-btn {
-      padding-top: 0.75rem;
-      padding-bottom: 0.75rem;
-      padding-left: 1.25rem;
-      padding-right: 1.25rem;
-      font-size: 1.125rem;
-      line-height: 1.75rem;
-      font-weight: 600;
-    }
+  .submit-btn:hover:not(:disabled) {
+    background: var(--color-primary-dark);
+    transform: translateY(-1px);
+    box-shadow: 0 14px 26px -8px rgba(255, 194, 14, 0.7);
   }
 </style>

--- a/src/components/sections/Faq.astro
+++ b/src/components/sections/Faq.astro
@@ -3,77 +3,83 @@ const { item } = Astro.props;
 const { title, list } = item;
 ---
 
-<div class="faq-accordion py-16 w-full relative">
-  <div
-    class="flex justify-between relative custom-container mx-auto !max-w-[900px] lg:flex-row flex-col items-start gap-8"
-  >
-    <div class="w-full">
+<section class="faq-accordion section bg-cream w-full relative">
+  <div class="container-narrow">
+    <div class="text-center">
+      <span class="eyebrow">FAQ</span>
       <h2
-        class="mb-12 text-secondary text-center sm:text-4xl text-3xl font-bold"
+        class="heading-lg mt-4"
         data-aos="fade-up"
         data-aos-duration="800"
       >
         {title}
       </h2>
-
-      <dl class="space-y-5">
-        {
-          list.map((faq, index) => (
-            <div
-              class="p-4 bg-[#FAFAFA] border border-[#E8E8E8] rounded-lg transition-all duration-300"
-              data-aos="fade-up"
-              data-aos-delay={100 + index * 50}
-              data-aos-duration="600"
-              data-aos-easing="ease-out"
-            >
-              <dt class="text-lg">
-                <button
-                  class="text-left w-full flex justify-between items-start focus:outline-none group"
-                  aria-controls={`faq-${index}`}
-                  aria-expanded="false"
-                  id={`faq-button-${index}`}
-                >
-                  <span class="font-medium text-secondary transition-colors duration-200">
-                    {faq.accordion_id.question}
-                  </span>
-                  <span class="ml-6 h-7 flex items-center">
-                    <svg
-                      width="24"
-                      height="24"
-                      class="h-6 w-6 transform transition-transform text-primary duration-300 ease-in-out"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                    >
-                      <path
-                        d="M14.2893 5.70708C13.8988 5.31655 13.2657 5.31655 12.8751 5.70708L7.98768 10.5993C7.20729 11.3805 7.2076 12.6463 7.98837 13.427L12.8787 18.3174C13.2693 18.7079 13.9024 18.7079 14.293 18.3174C14.6835 17.9269 14.6835 17.2937 14.293 16.9032L10.1073 12.7175C9.71678 12.327 9.71678 11.6939 10.1073 11.3033L14.2893 7.12129C14.6799 6.73077 14.6799 6.0976 14.2893 5.70708Z"
-                        fill="currentColor"
-                      />
-                    </svg>
-                  </span>
-                </button>
-              </dt>
-
-              <dd
-                class="overflow-hidden transition-all duration-300 ease-in-out max-h-0"
-                id={`faq-${index}`}
-                aria-labelledby={`faq-button-${index}`}
-              >
-                <div
-                  class="pt-3 prose text-text/80"
-                  set:html={faq.accordion_id.answer}
-                />
-              </dd>
-            </div>
-          ))
-        }
-      </dl>
+      <div class="accent-bar mx-auto"></div>
     </div>
+
+    <dl class="mt-12 space-y-4">
+      {
+        list.map((faq, index) => (
+          <div
+            class="p-4 border border-line bg-white px-5 py-2 shadow-[0_4px_24px_-12px_rgba(16,20,30,0.15)] transition-all duration-300 hover:border-primary/60"
+            data-aos="fade-up"
+            data-aos-delay={100 + index * 50}
+            data-aos-duration="600"
+            data-aos-easing="ease-out"
+          >
+            <dt>
+              <button
+                class="group/btn flex w-full items-center justify-between gap-4 py-4 text-left focus:outline-none"
+                aria-controls={`faq-${index}`}
+                aria-expanded="false"
+                id={`faq-button-${index}`}
+              >
+                <span class="text-base font-semibold text-dark transition-colors duration-200 md:text-lg">
+                  {faq.accordion_id.question}
+                </span>
+                <span class="faq-icon flex h-9 w-9 shrink-0 items-center justify-center bg-primary/15 text-dark transition-colors duration-200 group-hover/btn:bg-primary">
+                  <svg
+                    width="24"
+                    height="24"
+                    class="h-5 w-5 transform transition-transform duration-300 ease-in-out"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                  >
+                    <path
+                      d="M12 5v14M5 12h14"
+                      stroke="currentColor"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </dt>
+
+            <dd
+              class="overflow-hidden transition-all duration-300 ease-in-out max-h-0"
+              id={`faq-${index}`}
+              aria-labelledby={`faq-button-${index}`}
+            >
+              <div
+                class="prose-mibox max-w-none pb-5 pt-1 text-secondary"
+                set:html={faq.accordion_id.answer}
+              />
+            </dd>
+          </div>
+        ))
+      }
+    </dl>
   </div>
-</div>
+</section>
 
 <style>
+  /* Plus icon rotates to an x (45deg) when its panel is expanded */
   .faq-accordion button[aria-expanded="true"] svg {
-    @apply rotate-180;
+    transform: rotate(45deg);
+  }
+  .faq-accordion button[aria-expanded="true"] .faq-icon {
+    background-color: var(--color-primary);
   }
 </style>
 

--- a/src/components/sections/FindYouFit.astro
+++ b/src/components/sections/FindYouFit.astro
@@ -5,50 +5,70 @@ const { item } = Astro.props;
 const { title, cards } = item ?? {};
 ---
 
-<section class="relative">
-  <div class="custom-container lg:py-24 py-26">
-    <h2
-      class="text-4xl text-secondary lg:text-5xl text-center font-semibold mb-12"
-    >
-      {title}
-    </h2>
-    <div class="grid lg:grid-cols-3 md:grid-cols-2 grid-cols-1 gap-4">
+<section class="section bg-white relative">
+  <div class="custom-container">
+    <div class="section-head">
+      <span class="eyebrow">Container Sizes</span>
+      <h2 class="heading-lg mt-5">{title}</h2>
+      <div class="accent-bar mx-auto"></div>
+    </div>
+
+    <div class="mt-14 grid grid-cols-1 gap-7 md:grid-cols-2 lg:mt-16 lg:grid-cols-3">
       {
         cards?.map((item) => (
-          <div class="border border-black/70 rounded-2xl  p-4">
-            <img
-              src={getAssetURL(item?.container_card_id?.image?.id)}
-              alt={
-                item?.container_card_id?.image?.description ||
-                item?.container_card_id?.storageSize ||
-                "Container image"
-              }
-              class="w-full h-[200px] object-contain  rounded-xl mb-6"
-            />
-            {item?.container_card_id?.length && (
-              <h2 class="text-4xl font-bold mb-2 text-secondary">
-                {item?.container_card_id?.length}
-              </h2>
-            )}
-            {item?.size && (
-              <h3 class="text-xl mb-4">{item?.container_card_id?.size}</h3>
-            )}
+          <div class="card-flush card-hover group flex flex-col">
+            <div class="relative flex aspect-[4/3] items-center justify-center overflow-hidden bg-cream">
+              <img
+                src={getAssetURL(item?.container_card_id?.image?.id)}
+                alt={
+                  item?.container_card_id?.image?.description ||
+                  item?.container_card_id?.storageSize ||
+                  "Container image"
+                }
+                class="h-full w-full object-contain p-6 transition-transform duration-500 group-hover:scale-105"
+              />
+            </div>
 
-            <p>{item?.container_card_id?.description}</p>
-            {item?.container_card_id?.dimensions && (
-              <div class="flex justify-start items-center mt-4 gap-4">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  width="32"
-                  height="32"
-                  fill="currentColor"
-                  viewBox="0 0 256 256"
-                >
-                  <path d="M237.66,133.66l-32,32a8,8,0,0,1-11.32-11.32L212.69,136H43.31l18.35,18.34a8,8,0,0,1-11.32,11.32l-32-32a8,8,0,0,1,0-11.32l32-32a8,8,0,0,1,11.32,11.32L43.31,120H212.69l-18.35-18.34a8,8,0,0,1,11.32-11.32l32,32A8,8,0,0,1,237.66,133.66Z" />
-                </svg>
-                {item?.container_card_id?.dimensions}
-              </div>
-            )}
+            <div class="flex flex-1 flex-col p-6">
+              {item?.container_card_id?.length && (
+                <h3 class="heading-md mb-1 text-3xl">
+                  {item?.container_card_id?.length}
+                </h3>
+              )}
+              {item?.size && (
+                <h4 class="mb-3 text-base font-semibold text-secondary">
+                  {item?.container_card_id?.size}
+                </h4>
+              )}
+
+              <p class="text-sm leading-relaxed text-secondary">
+                {item?.container_card_id?.description}
+              </p>
+
+              {item?.container_card_id?.dimensions && (
+                <div class="mt-6 flex items-center gap-3 border-t border-line pt-5">
+                  <span class="icon-chip h-9 w-9 shrink-0">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="18"
+                      height="18"
+                      fill="currentColor"
+                      viewBox="0 0 256 256"
+                    >
+                      <path d="M237.66,133.66l-32,32a8,8,0,0,1-11.32-11.32L212.69,136H43.31l18.35,18.34a8,8,0,0,1-11.32,11.32l-32-32a8,8,0,0,1,0-11.32l32-32a8,8,0,0,1,11.32,11.32L43.31,120H212.69l-18.35-18.34a8,8,0,0,1,11.32-11.32l32,32A8,8,0,0,1,237.66,133.66Z" />
+                    </svg>
+                  </span>
+                  <span class="flex flex-col">
+                    <span class="text-[0.68rem] font-bold uppercase tracking-wider text-muted">
+                      Dimensions
+                    </span>
+                    <span class="text-sm font-semibold text-dark">
+                      {item?.container_card_id?.dimensions}
+                    </span>
+                  </span>
+                </div>
+              )}
+            </div>
           </div>
         ))
       }

--- a/src/components/sections/Footer.astro
+++ b/src/components/sections/Footer.astro
@@ -5,18 +5,19 @@ import { getFooter, getGlobal } from "src/lib/getPageData";
 const footer = await getFooter();
 let { pageUrl } = Astro.props;
 const global = await getGlobal();
+const isCold = ["cold-storage-containers", "thank-you-coolers"].includes(pageUrl);
 ---
 
-<footer class="bg-[#f7f7f7] text-dark py-12 lg:py-16">
-  <div class="custom-container mx-auto flex flex-wrap justify-between">
+<footer class="bg-ink text-gray-400">
+  <div class="custom-container py-14 lg:py-16">
     <!-- Logo -->
-    <div class="w-full flex justify-center mb-6">
+    <div class="flex w-full justify-center pb-10">
       {
-        !["cold-storage-containers", "thank-you-coolers"].includes(pageUrl) ? (
+        !isCold ? (
           <img
             src={getAssetURL(global.logo.id)}
-            alt={global.logo.description || global.logo.title || "Mi Box Logo"}
-            class="h-24 object-contain"
+            alt={global.logo.description || global.logo.title || "MI-BOX Logo"}
+            class="h-20 object-contain"
           />
         ) : (
           <img
@@ -28,54 +29,58 @@ const global = await getGlobal();
               global.logo.title ||
               " Logo"
             }
-            class="h-24 object-contain"
+            class="h-20 object-contain"
           />
         )
       }
     </div>
-    {
-      ["cold-storage-containers", "thank-you-coolers"].includes(pageUrl) ? "": (
-    <div
-      class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 w-full my-14 items-start gap-8"
-     >
-      {
-        footer?.footer_items?.map((section) => (
-          <div class="w-full mb-6">
-            <h3 class="text-lg font-semibold">
-              {section?.footer_item_id?.title}
-            </h3>
-            <ul class="mt-2 space-y-2">
-              {section?.footer_item_id?.links?.map((link) => (
-                <li>
-                  <a href={link?.link} class="text-dark hover:text-primary">
-                    {link?.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))
-      }
-    </div>
 
-    <div class="flex justify-center md:flex-row flex-col w-full gap-4">
-      {
-        footer?.legal_links?.map((item) => (
-          <a href={item?.link} class="text-dark text-xs hover:text-primary">
-            {item?.title}
-          </a>
-        ))
-      }
-    </div>
-    )}
+    {
+      isCold ? null : (
+        <>
+          <div class="grid w-full grid-cols-1 gap-8 border-t border-white/10 pt-12 md:grid-cols-3 lg:grid-cols-4">
+            {footer?.footer_items?.map((section) => (
+              <div class="w-full">
+                <h3 class="text-sm font-bold uppercase tracking-[0.12em] text-white">
+                  {section?.footer_item_id?.title}
+                </h3>
+                <ul class="mt-4 space-y-2.5">
+                  {section?.footer_item_id?.links?.map((link) => (
+                    <li>
+                      <a
+                        href={link?.link}
+                        class="text-[15px] text-gray-400 transition-colors hover:text-primary"
+                      >
+                        {link?.label}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+
+          <div class="mt-12 flex w-full flex-col justify-center gap-3 border-t border-white/10 pt-8 md:flex-row md:gap-6">
+            {footer?.legal_links?.map((item) => (
+              <a
+                href={item?.link}
+                class="text-center text-xs font-medium text-gray-500 transition-colors hover:text-primary"
+              >
+                {item?.title}
+              </a>
+            ))}
+          </div>
+        </>
+      )
+    }
 
     <!-- Cold Storage Contact Info -->
     {
-      ["cold-storage-containers", "thank-you-coolers"].includes(pageUrl) && (
-        <div class="w-full text-center text-sm mt-4 text-dark space-y-1">
+      isCold && (
+        <div class="w-full space-y-1 border-t border-white/10 pt-8 text-center text-sm text-gray-400">
           <p>6510 3rd Ave W, Bradenton, FL 34209</p>
           <p>
-            <a href="tel:19417777269" class="hover:text-primary">
+            <a href="tel:19417777269" class="transition-colors hover:text-primary">
               941-777-7269
             </a>
           </p>
@@ -84,9 +89,9 @@ const global = await getGlobal();
     }
 
     <!-- Copyright -->
-    <div class="w-full text-center text-sm mt-6 text-dark">
+    <div class="mt-8 w-full text-center text-xs text-gray-500">
       {
-        ["cold-storage-containers", "thank-you-coolers"].includes(pageUrl) ? (
+        isCold ? (
           <p>
             2026 Box Rental Now, LLC / It's Ice Cold Storage. All Rights
             Reserved

--- a/src/components/sections/Header.astro
+++ b/src/components/sections/Header.astro
@@ -9,7 +9,7 @@ const global = await getGlobal();
 ---
 
 <header
-  class="relative z-[990000] shadow-md transition-all duration-300"
+  class="relative z-[990000] border-b border-line bg-white shadow-[0_1px_0_0_rgba(16,20,30,0.04)] transition-all duration-300"
   id="navbar"
 >
   <div class="flex custom-container justify-between items-center py-4">
@@ -19,7 +19,7 @@ const global = await getGlobal();
           <div>
             <a
               href="/"
-              class="text-xl font-bold text-gray-800 flex items-center gap-2"
+              class="text-xl font-bold text-dark flex items-center gap-2"
             >
               <img
                 src={getAssetURL(global.logo.id)}
@@ -32,7 +32,7 @@ const global = await getGlobal();
             </a>
 
             {nav?.logo_tagline && (
-              <span class="text-sm text-gray-600">{nav.logo_tagline}</span>
+              <span class="text-sm text-muted">{nav.logo_tagline}</span>
             )}
           </div>
         ) : (
@@ -52,14 +52,14 @@ const global = await getGlobal();
     </div>
 
     <!-- Desktop Navigation -->
-    <nav class="hidden lg:flex space-x-8" id="navItems">
+    <nav class="hidden lg:flex items-center gap-8" id="navItems">
       {
         nav?.menu_items?.map((item) => {
           const navItem = item?.nav_item_id;
           const hasDropdown = navItem?.sub_menu && navItem.sub_menu.length > 0;
           return hasDropdown ? (
             <div class="relative group">
-              <button class="text-black underline-text font-medium hover:text-primary flex items-center gap-1 cursor-pointer">
+              <button class="nav-link flex items-center gap-1 cursor-pointer">
                 {navItem?.title}
                 <svg
                   class="w-4 h-4 transition-transform duration-200 group-hover:rotate-180"
@@ -74,11 +74,11 @@ const global = await getGlobal();
                   />
                 </svg>
               </button>
-              <div class="absolute top-full left-0 mt-2 w-48 bg-white rounded-md shadow-lg border border-gray-100 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
+              <div class="absolute top-full left-0 mt-3 w-52 bg-white shadow-[0_18px_40px_-18px_rgba(16,20,30,0.35)] border border-line opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
                 {navItem.sub_menu.map((sub: any) => (
                   <a
                     href={sub?.link}
-                    class="block px-4 py-2 text-sm text-black hover:bg-gray-50 hover:text-primary first:rounded-t-md last:rounded-b-md"
+                    class="block border-l-2 border-transparent px-4 py-2.5 text-sm font-medium text-dark transition-colors hover:border-primary hover:bg-cream hover:text-primary-dark"
                   >
                     {sub?.label}
                   </a>
@@ -86,10 +86,7 @@ const global = await getGlobal();
               </div>
             </div>
           ) : (
-            <a
-              href={navItem?.link}
-              class="text-black underline-text font-medium hover:text-primary"
-            >
+            <a href={navItem?.link} class="nav-link">
               {navItem?.title}
             </a>
           );
@@ -104,19 +101,19 @@ const global = await getGlobal();
           <div class="flex ">
             <a
               href={`tel:${global.phone_number}`}
-              class="text-black font-medium hover:text-primary flex items-center gap-2 duration-150"
+              class="btn-primary btn-sm hidden md:inline-flex"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                width="24"
-                height="24"
+                width="20"
+                height="20"
                 viewBox="0 0 24 24"
                 fill="none"
                 class=" flex "
                 data-src="https://cdn.hugeicons.com/icons/call-solid-rounded.svg"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 role="img"
-                color="#000000"
+                color="#1c1c1c"
               >
                 <path
                   d="M5.31726 1.28657C5.88395 1.40369 6.33524 1.78443 6.61564 2.28746L7.50885 3.88991C7.83786 4.48011 8.11473 4.9768 8.29554 5.40857C8.48735 5.86658 8.60126 6.31824 8.54919 6.8176C8.49711 7.31696 8.29246 7.7354 8.01029 8.14399C7.74428 8.52917 7.37088 8.95804 6.92718 9.46767L5.61417 10.9759C5.37889 11.2461 5.26124 11.3812 5.25049 11.5501C5.23974 11.719 5.33616 11.8633 5.529 12.1518C7.17259 14.6109 9.38773 16.8268 11.8488 18.4718C12.1374 18.6647 12.2816 18.7611 12.4505 18.7503C12.6194 18.7396 12.7546 18.6219 13.0248 18.3866L14.5331 17.0736C15.0427 16.6299 15.4716 16.2565 15.8568 15.9905C16.2653 15.7083 16.6838 15.5036 17.1831 15.4516C17.6825 15.3995 18.1342 15.5134 18.5922 15.7052C19.0239 15.886 19.5206 16.1629 20.1107 16.4918L21.7133 17.3851C22.2163 17.6655 22.5971 18.1168 22.7142 18.6835C22.8325 19.2561 22.658 19.8316 22.2724 20.3047C20.8735 22.021 18.6322 23.1139 16.281 22.6396C14.8358 22.348 13.4098 21.8623 11.6851 20.8732C8.2197 18.8858 5.11263 15.777 3.12755 12.3157C2.13843 10.591 1.65272 9.165 1.36118 7.71974C0.88688 5.36852 1.97971 3.12724 3.69608 1.72833C4.16911 1.34279 4.74466 1.16822 5.31726 1.28657Z"

--- a/src/components/sections/Header.astro
+++ b/src/components/sections/Header.astro
@@ -1,43 +1,81 @@
 ---
-import ImageMod from "@components/ui/ImageMod.astro";
 import { getAssetURL } from "@utils/getImage";
 import { getNavbar, getGlobal } from "src/lib/getPageData";
+import { getCollection } from "astro:content";
 
 const { pageUrl } = Astro.props;
 const nav = await getNavbar();
 const global = await getGlobal();
+
+const locations = (await getCollection("locations")).sort(
+  (a, b) => a.data.order - b.data.order,
+);
+
+const isCold = ["cold-storage-containers", "thank-you-coolers"].includes(
+  pageUrl,
+);
+
+const phoneTel = global?.phone_number || nav?.phone_number;
+const phoneDisplay = nav?.phone_number || global?.phone_number;
+
+// Curated mega-nav structure (the CMS nav is flat; this drives the 3-col
+// Services mega and is easy to maintain in one place).
+const services = [
+  {
+    title: "Moving",
+    link: "/moving-services",
+    desc: "Portable containers delivered to your door for stress-free local moves.",
+    icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-6 w-6"><path d="M1 6h13v9H1z"/><path d="M14 9h4l3 3v3h-7z"/><circle cx="5.5" cy="18" r="1.6"/><circle cx="17.5" cy="18" r="1.6"/></svg>`,
+    links: [
+      { label: "Moving Containers", link: "/moving-services" },
+      { label: "Service Areas", link: "/service-areas" },
+    ],
+  },
+  {
+    title: "Storage",
+    link: "/storage-services",
+    desc: "On-site and off-site storage with flexible month-to-month rentals.",
+    icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-6 w-6"><path d="M21 8l-9-5-9 5 9 5 9-5z"/><path d="M3 8v8l9 5 9-5V8"/><path d="M12 13v8"/></svg>`,
+    links: [
+      { label: "Storage Services", link: "/storage-services" },
+      { label: "Business & Inventory Storage", link: "/storage-services" },
+    ],
+  },
+  {
+    title: "Cold Storage",
+    link: "/cold-storage-containers",
+    desc: "Refrigerated container rentals for events, restaurants and seasonal needs.",
+    icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-6 w-6"><path d="M12 2v20M2 12h20M5 5l14 14M19 5L5 19"/></svg>`,
+    links: [
+      { label: "Cold Storage Containers", link: "/cold-storage-containers" },
+      { label: "Get a Cold Storage Quote", link: "/cold-storage-containers" },
+    ],
+  },
+];
+
+const phoneSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" class="h-[18px] w-[18px]"><path d="M5.32 1.29c.57.12 1.02.5 1.3 1l.89 1.6c.33.59.61 1.09.79 1.52.19.46.3.91.25 1.41-.05.5-.26.92-.54 1.33-.27.38-.64.81-1.08 1.32L5.61 11.55c-.23.27-.35.4-.36.57s.08.31.27.6c1.65 2.46 3.86 4.68 6.32 6.32.29.19.43.29.6.28s.3-.13.57-.36l1.51-1.31c.51-.44.94-.81 1.32-1.08.41-.28.83-.49 1.33-.54s.95.06 1.41.25c.43.18.93.46 1.52.79l1.6.89c.5.28.88.73 1 1.3.12.57-.06 1.15-.44 1.62-1.4 1.72-3.64 2.81-5.99 2.34-1.45-.29-2.87-.78-4.6-1.77C9.22 18.89 6.11 15.78 4.13 12.32c-.99-1.73-1.47-3.15-1.77-4.6C1.89 5.37 2.98 3.13 4.7 1.73c.47-.39 1.04-.56 1.62-.44z"/></svg>`;
 ---
 
 <header
-  class="relative z-[990000] border-b border-line bg-white shadow-[0_1px_0_0_rgba(16,20,30,0.04)] transition-all duration-300"
+  class="relative z-[990000] border-b border-line bg-white shadow-[0_1px_0_0_rgba(16,20,30,0.04)]"
   id="navbar"
 >
-  <div class="flex custom-container justify-between items-center py-4">
+  <div class="flex custom-container justify-between items-center gap-6 py-4">
+    <!-- Logo -->
     <div class="flex flex-col">
       {
-        !["cold-storage-containers", "thank-you-coolers"].includes(pageUrl) ? (
-          <div>
-            <a
-              href="/"
-              class="text-xl font-bold text-dark flex items-center gap-2"
-            >
-              <img
-                src={getAssetURL(global.logo.id)}
-                alt={
-                  global.logo.description || global.logo.title || "Mi Box Logo"
-                }
-                class="max-w-32"
-                loading="eager"
-              />
-            </a>
-
-            {nav?.logo_tagline && (
-              <span class="text-sm text-muted">{nav.logo_tagline}</span>
-            )}
-          </div>
+        !isCold ? (
+          <a href="/" class="flex items-center gap-2 text-dark">
+            <img
+              src={getAssetURL(global.logo.id)}
+              alt={global.logo.description || global.logo.title || "MI-BOX Logo"}
+              class="max-w-32"
+              loading="eager"
+            />
+          </a>
         ) : (
           <img
-            src={getAssetURL(global.ice_logo.id || global.logo.id)}
+            src={getAssetURL(global.ice_logo?.id || global.logo.id)}
             alt={
               global.ice_logo?.description ||
               global.ice_logo?.title ||
@@ -51,200 +89,262 @@ const global = await getGlobal();
       }
     </div>
 
-    <!-- Desktop Navigation -->
+    <!-- Desktop Mega Nav -->
     <nav class="hidden lg:flex items-center gap-8" id="navItems">
-      {
-        nav?.menu_items?.map((item) => {
-          const navItem = item?.nav_item_id;
-          const hasDropdown = navItem?.sub_menu && navItem.sub_menu.length > 0;
-          return hasDropdown ? (
-            <div class="relative group">
-              <button class="nav-link flex items-center gap-1 cursor-pointer">
-                {navItem?.title}
-                <svg
-                  class="w-4 h-4 transition-transform duration-200 group-hover:rotate-180"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-              </button>
-              <div class="absolute top-full left-0 mt-3 w-52 bg-white shadow-[0_18px_40px_-18px_rgba(16,20,30,0.35)] border border-line opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50">
-                {navItem.sub_menu.map((sub: any) => (
-                  <a
-                    href={sub?.link}
-                    class="block border-l-2 border-transparent px-4 py-2.5 text-sm font-medium text-dark transition-colors hover:border-primary hover:bg-cream hover:text-primary-dark"
-                  >
-                    {sub?.label}
-                  </a>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <a href={navItem?.link} class="nav-link">
-              {navItem?.title}
-            </a>
-          );
-        })
-      }
-    </nav>
+      <!-- Services (3-col mega) -->
+      <div class="group static">
+        <button
+          class="nav-link flex items-center gap-1 cursor-pointer"
+          aria-haspopup="true"
+        >
+          Services
+          <svg
+            class="w-4 h-4 transition-transform duration-200 group-hover:rotate-180"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+              clip-rule="evenodd"
+            ></path>
+          </svg>
+        </button>
 
-    <!-- Phone CTA -->
-    <div class="flex items-center gap-4">
-      {
-        global?.phone_number && (
-          <div class="flex ">
-            <a
-              href={`tel:${global.phone_number}`}
-              class="btn-primary btn-sm hidden md:inline-flex"
+        <div
+          class="invisible absolute left-0 right-0 top-full z-50 -translate-y-1 border-y border-line bg-white opacity-0 shadow-[0_28px_56px_-28px_rgba(16,20,30,0.4)] transition-all duration-200 before:absolute before:inset-x-0 before:-top-5 before:h-5 before:content-[''] group-hover:visible group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+        >
+          <div class="custom-container py-9">
+            <div class="grid gap-8 lg:grid-cols-3">
+              {
+                services.map((s) => (
+                  <div>
+                    <a href={s.link} class="flex items-start gap-4">
+                      <span class="icon-chip-dark shrink-0" set:html={s.icon} />
+                      <span class="block">
+                        <span class="block font-extrabold text-dark">
+                          {s.title}
+                        </span>
+                        <span class="mt-1 block text-sm leading-relaxed text-secondary">
+                          {s.desc}
+                        </span>
+                      </span>
+                    </a>
+                    <ul class="mt-4 space-y-1 border-t border-line pt-4">
+                      {s.links.map((l) => (
+                        <li>
+                          <a
+                            href={l.link}
+                            class="block border-l-2 border-transparent py-1.5 pl-3 text-sm font-medium text-dark transition-colors hover:border-primary hover:text-primary-dark"
+                          >
+                            {l.label}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))
+              }
+            </div>
+          </div>
+          <div class="border-t border-line bg-cream">
+            <div
+              class="custom-container flex flex-wrap items-center justify-between gap-4 py-4"
             >
+              <p class="text-sm font-semibold text-dark">
+                Not sure which option fits? We'll help you choose.
+              </p>
+              <a href="/contact-us" class="btn-primary btn-sm">
+                Get a Free Quote
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Locations (mega grid from the collection) -->
+      {
+        locations.length > 0 && (
+          <div class="group static">
+            <button
+              class="nav-link flex items-center gap-1 cursor-pointer"
+              aria-haspopup="true"
+            >
+              Locations
               <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                class=" flex "
-                data-src="https://cdn.hugeicons.com/icons/call-solid-rounded.svg"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-                role="img"
-                color="#1c1c1c"
+                class="w-4 h-4 transition-transform duration-200 group-hover:rotate-180"
+                viewBox="0 0 20 20"
+                fill="currentColor"
               >
                 <path
-                  d="M5.31726 1.28657C5.88395 1.40369 6.33524 1.78443 6.61564 2.28746L7.50885 3.88991C7.83786 4.48011 8.11473 4.9768 8.29554 5.40857C8.48735 5.86658 8.60126 6.31824 8.54919 6.8176C8.49711 7.31696 8.29246 7.7354 8.01029 8.14399C7.74428 8.52917 7.37088 8.95804 6.92718 9.46767L5.61417 10.9759C5.37889 11.2461 5.26124 11.3812 5.25049 11.5501C5.23974 11.719 5.33616 11.8633 5.529 12.1518C7.17259 14.6109 9.38773 16.8268 11.8488 18.4718C12.1374 18.6647 12.2816 18.7611 12.4505 18.7503C12.6194 18.7396 12.7546 18.6219 13.0248 18.3866L14.5331 17.0736C15.0427 16.6299 15.4716 16.2565 15.8568 15.9905C16.2653 15.7083 16.6838 15.5036 17.1831 15.4516C17.6825 15.3995 18.1342 15.5134 18.5922 15.7052C19.0239 15.886 19.5206 16.1629 20.1107 16.4918L21.7133 17.3851C22.2163 17.6655 22.5971 18.1168 22.7142 18.6835C22.8325 19.2561 22.658 19.8316 22.2724 20.3047C20.8735 22.021 18.6322 23.1139 16.281 22.6396C14.8358 22.348 13.4098 21.8623 11.6851 20.8732C8.2197 18.8858 5.11263 15.777 3.12755 12.3157C2.13843 10.591 1.65272 9.165 1.36118 7.71974C0.88688 5.36852 1.97971 3.12724 3.69608 1.72833C4.16911 1.34279 4.74466 1.16822 5.31726 1.28657Z"
-                  fill="#000000"
+                  fill-rule="evenodd"
+                  d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                  clip-rule="evenodd"
                 />
               </svg>
-              <span class="md:block hidden">{nav.phone_number}</span>
-            </a>
+            </button>
+
+            <div class="invisible absolute left-0 right-0 top-full z-50 -translate-y-1 border-y border-line bg-white opacity-0 shadow-[0_28px_56px_-28px_rgba(16,20,30,0.4)] transition-all duration-200 group-hover:visible group-hover:translate-y-0 group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
+              <div class="custom-container py-9">
+                <div class="flex items-center justify-between">
+                  <span class="eyebrow">Gulf Coast Service Areas</span>
+                  <a
+                    href="/service-areas"
+                    class="text-sm font-semibold text-dark transition-colors hover:text-primary-dark"
+                  >
+                    All service areas →
+                  </a>
+                </div>
+                <div class="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+                  {locations.map((l) => (
+                    <a
+                      href={`/locations/${l.id}`}
+                      class="group/city flex flex-col border border-line bg-white px-5 py-4 transition-colors hover:border-primary hover:bg-cream"
+                    >
+                      <span class="font-bold text-dark">{l.data.city}</span>
+                      <span class="text-xs text-muted">
+                        {l.data.state} • {l.data.region}
+                      </span>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </div>
           </div>
         )
       }
+
+      <a href="/about-us" class="nav-link">About</a>
+      <a href="/blog" class="nav-link">Blog</a>
+      <a href="/contact-us" class="nav-link">Contact</a>
+    </nav>
+
+    <!-- Phone CTA + mobile toggle -->
+    <div class="flex items-center gap-4">
       {
-        nav?.menu_items?.length > 0 && (
-          <button class="lg:hidden text-black text-3xl" id="menuBtn">
-            <svg
-              width="64px"
-              height="64px"
-              class="w-8 h-8"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <>
-                <g id="SVGRepo_bgCarrier" stroke-width="0" />
-                <g
-                  id="SVGRepo_tracerCarrier"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <g id="SVGRepo_iconCarrier">
-                  {" "}
-                  <path
-                    d="M4 6H20M4 12H20M4 18H20"
-                    stroke="#000000"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />{" "}
-                </g>
-              </>
-            </svg>
-          </button>
+        phoneTel && (
+          <a
+            href={`tel:${phoneTel}`}
+            class="btn-primary btn-sm hidden md:inline-flex"
+          >
+            <span class="text-dark" set:html={phoneSvg} />
+            <span>{phoneDisplay}</span>
+          </a>
         )
       }
+      <button class="lg:hidden text-dark" id="menuBtn" aria-label="Open menu">
+        <svg
+          class="w-8 h-8"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M4 6H20M4 12H20M4 18H20"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"></path>
+        </svg>
+      </button>
     </div>
   </div>
 </header>
 
 <!-- Mobile Menu -->
 <div
-  class="lg:hidden fixed top-0 right-0 w-full h-full bg-gray-900/70 z-[990000] hidden transition-all duration-300"
+  class="lg:hidden fixed top-0 right-0 w-full h-full bg-ink/70 z-[990000] hidden"
   id="mobileMenu"
 >
   <div
-    class="bg-white ml-auto w-72 h-full p-4 shadow-lg overflow-y-auto duration-300"
+    class="bg-white ml-auto w-80 max-w-[85vw] h-full p-5 shadow-2xl overflow-y-auto"
   >
-    <button class="absolute top-4 right-4 text-black text-2xl" id="closeMenu"
-      >✕</button
+    <button
+      class="absolute top-4 right-4 text-dark text-2xl"
+      id="closeMenu"
+      aria-label="Close menu">✕</button
     >
-    <nav class="mt-12 border-b border-black/20 divide-y divide-black/20">
+    <nav class="mt-12 divide-y divide-line border-y border-line">
+      <!-- Services accordion -->
+      <div>
+        <button
+          class="mobile-accordion-btn flex w-full items-center justify-between py-3 font-semibold text-dark"
+          data-index="0"
+        >
+          <span>Services</span>
+          <svg class="w-4 h-4 transition-transform" viewBox="0 0 20 20" fill="currentColor">
+            <path
+              fill-rule="evenodd"
+              d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+              clip-rule="evenodd"></path>
+          </svg>
+        </button>
+        <div class="mobile-accordion-panel hidden pb-2 pl-3" data-index="0">
+          {
+            services.map((s) => (
+              <a
+                href={s.link}
+                class="block py-1.5 text-sm font-medium text-dark hover:text-primary-dark"
+              >
+                {s.title}
+              </a>
+            ))
+          }
+        </div>
+      </div>
+
+      <!-- Locations accordion -->
       {
-        nav?.menu_items?.map((item, index) => {
-          const navItem = item?.nav_item_id;
-          const hasDropdown = navItem?.sub_menu && navItem.sub_menu.length > 0;
-          return hasDropdown ? (
-            <div>
-              <button
-                class="w-full flex justify-between items-center py-2 text-black hover:bg-gray-100 mobile-accordion-btn"
-                data-index={index}
-              >
-                <span>{navItem?.title}</span>
-                <svg
-                  class="w-4 h-4 transition-transform duration-200"
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
-                    clip-rule="evenodd"
-                  />
-                </svg>
-              </button>
-              <div
-                class="hidden pl-4 pb-1 mobile-accordion-panel"
-                data-index={index}
-              >
-                {navItem.sub_menu.map((sub: any) => (
-                  <a
-                    href={sub?.link}
-                    class="block py-1.5 text-sm text-black hover:bg-gray-100"
-                  >
-                    {sub?.label}
-                  </a>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <a
-              href={navItem?.link}
-              class="block py-2 text-black hover:bg-gray-100"
+        locations.length > 0 && (
+          <div>
+            <button
+              class="mobile-accordion-btn flex w-full items-center justify-between py-3 font-semibold text-dark"
+              data-index="1"
             >
-              {navItem?.title}
-            </a>
-          );
-        })
+              <span>Locations</span>
+              <svg class="w-4 h-4 transition-transform" viewBox="0 0 20 20" fill="currentColor">
+                <path
+                  fill-rule="evenodd"
+                  d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </button>
+            <div class="mobile-accordion-panel hidden pb-2 pl-3" data-index="1">
+              {locations.map((l) => (
+                <a
+                  href={`/locations/${l.id}`}
+                  class="block py-1.5 text-sm font-medium text-dark hover:text-primary-dark"
+                >
+                  {l.data.city}
+                </a>
+              ))}
+              <a
+                href="/service-areas"
+                class="block py-1.5 text-sm font-semibold text-primary-dark"
+              >
+                All service areas →
+              </a>
+            </div>
+          </div>
+        )
       }
+
+      <a href="/about-us" class="block py-3 font-semibold text-dark">About</a>
+      <a href="/blog" class="block py-3 font-semibold text-dark">Blog</a>
+      <a href="/contact-us" class="block py-3 font-semibold text-dark">Contact</a>
     </nav>
+
+    {
+      phoneTel && (
+        <a href={`tel:${phoneTel}`} class="btn-primary btn-block mt-6">
+          <span class="text-dark" set:html={phoneSvg} />
+          <span>{phoneDisplay}</span>
+        </a>
+      )
+    }
   </div>
 </div>
-
-<style>
-  .underline-text {
-    padding-bottom: 2px;
-    background-image: linear-gradient(
-      var(--color-primary),
-      var(--color-primary)
-    );
-    background-position: 0 100%;
-    background-size: 0% 2px;
-    background-repeat: no-repeat;
-    transition:
-      background-size 0.3s,
-      background-position 0s 0.3s;
-  }
-  .underline-text:hover {
-    background-position: 100% 100%;
-    background-size: 100% 2px;
-  }
-</style>
 
 <script>
   function init() {

--- a/src/components/sections/HowPodsWorks.astro
+++ b/src/components/sections/HowPodsWorks.astro
@@ -6,102 +6,113 @@ const { item } = Astro.props;
 const { title, tabs, image, video_link, featured_media } = item;
 ---
 
-<div class="max-w-6xl px-6 mx-auto !py-16 lg:!py-24 relative">
-  <h2
-    class="text-4xl text-secondary lg:text-5xl text-center font-semibold mb-12"
-  >
-    {title}
-  </h2>
-
-  <div class="flex justify-center items-center lg:flex-row flex-col gap-20">
-    <div class="h-auto relative lg:w-1/2 w-full">
-      {
-        tabs.map((tab, index) => (
-          <div
-            role="tabpanel"
-            id={`tabpanel-${tab.id}`}
-            aria-labelledby={`tab-${tab.id}`}
-            class={`tab-panel flex flex-col gap-10 overflow-hidden transition duration-300 ${
-              index === 0 ? "flex" : "hidden"
-            }`}
-          >
-            {tab.tabs_id.steps.map((step, stepIndex) => (
-              <div class="relative flex items-start">
-                <div class="relative pr-5 h-full">
-                  <div class="bg-primary number">{stepIndex + 1}</div>
-                  {stepIndex !== tab.tabs_id.steps.length - 1 && (
-                    <div class="number-line bg-primary" />
-                  )}
-                </div>
-
-                <div>
-                  <h3 class="text-2xl font-semibold mb-2 text-black">
-                    {step.title}
-                  </h3>
-                  <p class="text-xl font-light">{step.description}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        ))
-      }
+<section class="section bg-cream relative">
+  <div class="custom-container">
+    <div class="section-head">
+      <span class="eyebrow">How It Works</span>
+      <h2 class="heading-lg mt-4">{title}</h2>
+      <div class="accent-bar mx-auto"></div>
     </div>
 
-    <div class="lg:w-1/2 w-full">
-      <div
-        role="tablist"
-        aria-label="tabs"
-        class="relative flex border rounded-lg w-full mb-12 items-start overflow-hidden mt-8 transition"
-      >
+    <div class="mt-14 grid grid-cols-1 items-start gap-12 lg:mt-16 lg:grid-cols-2 lg:gap-16">
+      <div class="relative order-2 w-full lg:order-1">
         {
           tabs.map((tab, index) => (
-            <button
-              role="tab"
-              aria-selected={index === 0 ? "true" : "false"}
-              aria-controls={`tabpanel-${tab.id}`}
-              id={`tab-${tab.id}`}
-              class={`relative block flex-1 px-6 py-2 tab ${
-                index === 0 ? "active" : ""
+            <div
+              role="tabpanel"
+              id={`tabpanel-${tab.id}`}
+              aria-labelledby={`tab-${tab.id}`}
+              class={`tab-panel flex-col gap-6 transition duration-300 ${
+                index === 0 ? "flex" : "hidden"
               }`}
             >
-              <span class="font-medium text-2xl whitespace-nowrap">
-                {tab.tabs_id.title}
-              </span>
-            </button>
+              {tab.tabs_id.steps.map((step, stepIndex) => (
+                <div class="group relative flex items-start gap-5">
+                  <div class="relative shrink-0">
+                    <div class="bg-primary text-dark number">{stepIndex + 1}</div>
+                    {stepIndex !== tab.tabs_id.steps.length - 1 && (
+                      <div class="number-line bg-gradient-to-b from-primary to-primary/20" />
+                    )}
+                  </div>
+
+                  <div class="card card-hover flex-1 !p-5">
+                    <h3 class="mb-1.5 text-lg font-bold text-dark md:text-xl">
+                      {step.title}
+                    </h3>
+                    <p class="text-base leading-relaxed text-secondary">
+                      {step.description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
           ))
         }
       </div>
 
-      {
-        featured_media === "image" ? (
-          <img
-            src={getAssetURL(image.id)}
-            alt={image.description || image.title || "How It Works Image"}
-            class="w-full h-full object-cover rounded-2xl"
-          />
-        ) : (
-          <iframe
-            class="w-full h-full rounded-2xl aspect-video"
-            src={`https://www.youtube.com/embed/${video_link}?autoplay=0&mute=1&loop=1&playlist=${video_link}`}
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen
-          />
-        )
-      }
+      <div class="order-1 w-full lg:sticky lg:top-28 lg:order-2">
+        <div
+          role="tablist"
+          aria-label="tabs"
+          class="mb-6 flex gap-1.5 bg-white p-1.5 shadow-[0_4px_24px_-10px_rgba(16,20,30,0.14)] ring-1 ring-black/5"
+        >
+          {
+            tabs.map((tab, index) => (
+              <button
+                role="tab"
+                aria-selected={index === 0 ? "true" : "false"}
+                aria-controls={`tabpanel-${tab.id}`}
+                id={`tab-${tab.id}`}
+                class={`tab relative flex-1 px-5 py-3 text-center text-sm font-bold text-secondary sm:text-base ${
+                  index === 0 ? "active" : ""
+                }`}
+              >
+                <span class="whitespace-nowrap">{tab.tabs_id.title}</span>
+              </button>
+            ))
+          }
+        </div>
+
+        {
+          featured_media === "image" ? (
+            <div class="relative overflow-hidden shadow-xl ring-1 ring-black/10">
+              <img
+                src={getAssetURL(image.id)}
+                alt={image.description || image.title || "How It Works Image"}
+                class="w-full h-full object-cover"
+              />
+            </div>
+          ) : (
+            <iframe
+              class="w-full h-full aspect-video ring-1 ring-black/10"
+              src={`https://www.youtube.com/embed/${video_link}?autoplay=0&mute=1&loop=1&playlist=${video_link}`}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            />
+          )
+        }
+      </div>
     </div>
   </div>
-</div>
+</section>
 
 <style>
   .tab {
     transition:
       background-color 0.3s,
-      color 0.3s;
+      color 0.3s,
+      box-shadow 0.3s;
   }
 
   .tab.active {
-    border-left: 1px solid #000;
-    background-color: rgba(0, 42, 92, 0.1);
+    background-color: #ffc20e;
+    color: #1c1c1c;
+    box-shadow: 0 8px 20px -10px rgba(255, 194, 14, 0.7);
+  }
+
+  .tab:not(.active):hover {
+    color: #1c1c1c;
+    background-color: #faf8f2;
   }
 
   .tab-panel {
@@ -113,27 +124,22 @@ const { title, tabs, image, video_link, featured_media } = item;
     justify-content: center;
     align-items: center;
     margin: 0;
-    border-radius: 8px;
     width: 48px;
     height: 48px;
-    color: #fff;
-    font-size: 32px;
+    color: #1c1c1c;
+    font-size: 22px;
+    font-weight: 800;
     position: relative;
+    z-index: 1;
   }
 
   .number-line {
     position: absolute;
-    width: 4px;
-    left: 33.33%;
-    top: 40px;
+    width: 3px;
+    left: 24px;
+    top: 48px;
     transform: translateX(-50%);
-    height: calc(100% + 4rem);
-  }
-
-  @media (min-width: 1024px) {
-    .number-line {
-      height: calc(100% + 6rem);
-    }
+    height: calc(100% + 1.5rem);
   }
 </style>
 

--- a/src/components/sections/LogoSlider.astro
+++ b/src/components/sections/LogoSlider.astro
@@ -9,13 +9,14 @@ const logos = [
 ];
 ---
 
-<div class="bg-white py-16">
+<section class="surface section-tight">
   <div class="custom-container">
-    <h1
-      class="text-4xl text-secondary lg:text-5xl text-center font-semibold mb-12"
-    >
-      {item?.title}
-    </h1>
+    <div class="section-head mb-12">
+      <h2 class="heading-lg">
+        {item?.title}
+      </h2>
+      <div class="accent-bar mx-auto"></div>
+    </div>
     <div
       class="logos overlay relative"
       data-aos="fade-fade-up"
@@ -26,7 +27,7 @@ const logos = [
         {
           logos.map((logo, index) => (
             <img
-              class="img object-contain"
+              class="img object-contain grayscale opacity-60 transition duration-300 hover:grayscale-0 hover:opacity-100"
               src={getAssetURL(logo.image_id.image.id)}
               alt={
                 logo.image_id.image.description ||
@@ -41,7 +42,7 @@ const logos = [
       </div>
     </div>
   </div>
-</div>
+</section>
 
 <style>
   .logos {
@@ -66,8 +67,8 @@ const logos = [
     left: 0;
     background: linear-gradient(
       to left,
-      rgba(255, 255, 255, 0),
-      rgb(255, 255, 255)
+      rgba(246, 247, 249, 0),
+      rgb(246, 247, 249)
     );
   }
 
@@ -82,8 +83,8 @@ const logos = [
     right: 0;
     background: linear-gradient(
       to right,
-      rgba(255, 255, 255, 0),
-      rgb(255, 255, 255)
+      rgba(246, 247, 249, 0),
+      rgb(246, 247, 249)
     );
   }
 

--- a/src/components/sections/MainHero.astro
+++ b/src/components/sections/MainHero.astro
@@ -12,8 +12,8 @@ const stats = item?.stats ?? [];
 const SectionTitle = item?.sectionTitle ?? "";
 ---
 
-<div class="md:h-[800px] h-full relative">
-  <div class="w-full bg-white rounded-lg md:hidden block p-4 md:p-8">
+<div class="md:h-[800px] h-full relative bg-ink">
+  <div class="form-card md:hidden block">
     <QuoteForm
       client:only="svelte"
       quoteFormTitle={quoteFormTitle}
@@ -42,11 +42,15 @@ const SectionTitle = item?.sectionTitle ?? "";
       class="custom-container mx-auto h-full flex items-end px-4 md:px-8 relative"
     >
       <div class="text-white md:w-1/2 py-12">
-        <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-4 fade-up">
+        <span class="eyebrow eyebrow-light mb-5 fade-up">
+          Moving &amp; Storage
+        </span>
+        <h1 class="display text-white mt-5 mb-4 fade-up">
           {item?.title}
         </h1>
+        <span class="accent-bar fade-up"></span>
         <div
-          class="text-lg md:text-xl text-white font-medium fade-up prose"
+          class="lead mt-5 max-w-xl text-white/90 fade-up prose-mibox prose-invert"
           set:html={item?.description}
         />
       </div>
@@ -54,9 +58,9 @@ const SectionTitle = item?.sectionTitle ?? "";
   </div>
 
   <div
-    class="md:absolute md:flex hidden top-0 right-0 h-full w-full md:w-1/2 items-center justify-center z-10"
+    class="md:absolute md:flex hidden top-0 right-0 h-full w-full md:w-1/2 items-center justify-center z-10 px-6"
   >
-    <div class="w-full bg-white rounded-lg lg:max-w-[550px] p-4 md:p-8">
+    <div class="w-full lg:max-w-[550px] form-card">
       <QuoteForm
         client:only="svelte"
         quoteFormTitle={quoteFormTitle}
@@ -70,25 +74,27 @@ const SectionTitle = item?.sectionTitle ?? "";
 
 {
   showStats && (
-    <div class="bg-[#E5EFFC] py-10 custom-container ">
-      <h2 class="text-sm font-semibold uppercase tracking-wider text-secondary mb-10 text-center ">
-        {SectionTitle}
-      </h2>
-      <div class="mx-auto px-4 grid grid-cols-1 sm:grid-cols-3 text-center gap-8">
-        {stats.map((stat: any) => (
-          <div class="flex flex-col lg:flex-row justify-center items-center gap-2">
-            <img
-              src={stat.icon}
-              alt={stat.label}
-              width={32}
-              height={32}
-              loading="eager"
-              decoding="async"
-            />
-            <p class="text-xl font-bold text-gray-800">{stat.value}</p>
-            <p class="text-sm text-secondary">{stat.label}</p>
-          </div>
-        ))}
+    <div class="surface section-tight">
+      <div class="custom-container">
+        <h2 class="eyebrow mb-10 mx-auto w-fit">
+          {SectionTitle}
+        </h2>
+        <div class="mx-auto grid grid-cols-1 sm:grid-cols-3 text-center gap-8">
+          {stats.map((stat: any) => (
+            <div class="flex flex-col justify-center items-center gap-2">
+              <img
+                src={stat.icon}
+                alt={stat.label}
+                width={32}
+                height={32}
+                loading="eager"
+                decoding="async"
+              />
+              <p class="stat-num">{stat.value}</p>
+              <p class="stat-label">{stat.label}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )
@@ -98,8 +104,8 @@ const SectionTitle = item?.sectionTitle ?? "";
   :root {
     --gradient-direction: linear-gradient(
       to bottom,
-      rgba(0, 154, 214, 0.7),
-      rgba(41, 147, 188, 0)
+      rgba(18, 20, 23, 0.78),
+      rgba(18, 20, 23, 0.2)
     );
   }
 
@@ -107,9 +113,9 @@ const SectionTitle = item?.sectionTitle ?? "";
     :root {
       --gradient-direction: linear-gradient(
         to top,
-        rgba(0, 154, 214, 0.7),
-        rgba(41, 147, 188, 0),
-        rgba(41, 147, 188, 0)
+        rgba(18, 20, 23, 0.85),
+        rgba(18, 20, 23, 0.45),
+        rgba(18, 20, 23, 0.15)
       );
     }
   }

--- a/src/components/sections/Masonry.astro
+++ b/src/components/sections/Masonry.astro
@@ -5,50 +5,54 @@ const { item } = Astro.props;
 const { title, images } = item;
 ---
 
-<section class="custom-container py-12 relative">
-  <h2
-    class="text-4xl text-secondary lg:text-5xl text-center font-semibold mb-8"
-  >
-    {title}
-  </h2>
-  <div class="lg:columns-3 md:columns-2 md:block hidden gap-4 space-y-4">
-    {
-      images.map((image) => (
-        <div class="relative overflow-hidden rounded-lg">
-          <img
-            src={getAssetURL(image.image_id.image.id)}
-            alt={
-              image.image_id.image.description ||
-              image.image_id.image.title ||
-              ""
-            }
-            class="w-full h-full object-cover"
-          />
-        </div>
-      ))
-    }
-  </div>
-  <div class="md:hidden block">
-    <div class="swiper masony-slider">
-      <div class="swiper-wrapper">
-        {
-          images.map((image) => (
-            <div class="swiper-slide">
-              <div class="relative overflow-hidden rounded-lg ">
-                <img
-                  src={getAssetURL(image.image_id.image.id)}
-                  alt={
-                    image.image_id.image.description ||
-                    image.image_id.image.title ||
-                    ""
-                  }
-                  class="w-full h-[400px] object-cover"
-                />
-                <div class="absolute inset-0 bg-black bg-opacity-50 flex justify-center items-center opacity-0 hover:opacity-100 transition-all duration-300" />
+<section class="section bg-cream relative">
+  <div class="custom-container">
+    <div class="section-head">
+      <span class="eyebrow">Gallery</span>
+      <h2 class="heading-lg mt-5">{title}</h2>
+    </div>
+
+    <div class="mt-12 lg:columns-3 md:columns-2 md:block hidden gap-3 space-y-3">
+      {
+        images.map((image) => (
+          <div class="group relative mb-3 break-inside-avoid overflow-hidden shadow-[0_4px_24px_-10px_rgba(16,20,30,0.18)] ring-1 ring-black/5 transition-all duration-300 hover:shadow-[0_22px_48px_-18px_rgba(16,20,30,0.3)]">
+            <img
+              src={getAssetURL(image.image_id.image.id)}
+              alt={
+                image.image_id.image.description ||
+                image.image_id.image.title ||
+                ""
+              }
+              class="w-full h-full object-cover transition-transform duration-[600ms] ease-out group-hover:scale-105"
+            />
+            <div class="overlay-grad-b opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+          </div>
+        ))
+      }
+    </div>
+
+    <div class="mt-12 md:hidden block">
+      <div class="swiper masony-slider">
+        <div class="swiper-wrapper">
+          {
+            images.map((image) => (
+              <div class="swiper-slide">
+                <div class="group relative overflow-hidden shadow-[0_4px_24px_-10px_rgba(16,20,30,0.18)] ring-1 ring-black/5">
+                  <img
+                    src={getAssetURL(image.image_id.image.id)}
+                    alt={
+                      image.image_id.image.description ||
+                      image.image_id.image.title ||
+                      ""
+                    }
+                    class="w-full h-[400px] object-cover transition-transform duration-[600ms] ease-out group-hover:scale-105"
+                  />
+                  <div class="overlay-grad-b opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                </div>
               </div>
-            </div>
-          ))
-        }
+            ))
+          }
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/sections/ReviewsSlider.astro
+++ b/src/components/sections/ReviewsSlider.astro
@@ -7,58 +7,62 @@ const { title, cards } = item;
 const reviews = shuffleArray(cards);
 ---
 
-<div
-  class="overflow-hidden custom-container lg:py-16 px-6 lg:px-0 py-12 relative"
-  data-aos="fade-up"
->
-  <div class="fade-up relative">
-    <div class="flex items-center gap-12 justify-between flex-col mb-12">
-      {
-        title && (
-          <h2 class="text-4xl text-secondary lg:text-5xl text-center font-semibold mb-12">
-            {title}
-          </h2>
-        )
-      }
-    </div>
-
-    <div class="swiper mySwiper">
-      <div class="swiper-wrapper">
+<section class="surface">
+  <div
+    class="overflow-hidden custom-container section relative"
+    data-aos="fade-up"
+  >
+    <div class="fade-up relative">
+      <div class="section-head mb-12">
+        <span class="eyebrow">Customer Reviews</span>
         {
-          reviews.map((review: any) => (
-            <div class="swiper-slide bg-white p-6 rounded-xl shadow-md shadow-gray-900/5 border-2 border-gray-100">
-              <div class="flex flex-col h-full min-h-[280px] ">
-                <div class="flex items-center gap-4 mb-4">
-                  <div class="bg-primary w-10 h-10 flex justify-center items-center text-white text-xl uppercase font-bold rounded-full">
-                    {review.testimonial_card_id.name[0]}
-                  </div>
-                  <div>
-                    <p class="font-semibold text-sm">
-                      {review.testimonial_card_id.name}
-                    </p>
-                    <div class="text-yellow-400 flex items-center">
-                      {[...Array(review.testimonial_card_id.rating)].map(
-                        (_, i) => (
-                          <svg class="w-4 h-4 fill-current" viewBox="0 0 24 24">
-                            <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
-                          </svg>
-                        )
-                      )}
+          title && (
+            <h2 class="heading-lg mt-5">
+              {title}
+            </h2>
+          )
+        }
+        <div class="accent-bar mx-auto"></div>
+      </div>
+
+      <div class="swiper mySwiper">
+        <div class="swiper-wrapper">
+          {
+            reviews.map((review: any) => (
+              <div class="swiper-slide card h-auto">
+                <div class="flex flex-col h-full min-h-[280px]">
+                  <div class="flex items-center gap-4 mb-4">
+                    <div class="icon-chip-dark h-10 w-10 shrink-0 text-xl uppercase font-extrabold">
+                      {review.testimonial_card_id.name[0]}
+                    </div>
+                    <div>
+                      <p class="font-bold text-sm text-dark">
+                        {review.testimonial_card_id.name}
+                      </p>
+                      <div class="stars">
+                        {[...Array(review.testimonial_card_id.rating)].map(
+                          (_, i) => (
+                            <svg class="w-4 h-4 fill-current" viewBox="0 0 24 24">
+                              <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+                            </svg>
+                          )
+                        )}
+                      </div>
                     </div>
                   </div>
+                  <p
+                    class="text-secondary leading-relaxed line-clamp-[7]"
+                    set:html={review.testimonial_card_id.content}
+                  />
                 </div>
-                <p
-                  class="text-gray-600 line-clamp-[7]"
-                  set:html={review.testimonial_card_id.content}
-                />
               </div>
-            </div>
-          ))
-        }
+            ))
+          }
+        </div>
       </div>
     </div>
   </div>
-</div>
+</section>
 
 <script>
   import Swiper from "swiper";

--- a/src/components/sections/ReviewsSlider.astro
+++ b/src/components/sections/ReviewsSlider.astro
@@ -29,32 +29,30 @@ const reviews = shuffleArray(cards);
         <div class="swiper-wrapper">
           {
             reviews.map((review: any) => (
-              <div class="swiper-slide card h-auto">
-                <div class="flex flex-col h-full min-h-[280px]">
-                  <div class="flex items-center gap-4 mb-4">
-                    <div class="icon-chip-dark h-10 w-10 shrink-0 text-xl uppercase font-extrabold">
-                      {review.testimonial_card_id.name[0]}
-                    </div>
-                    <div>
-                      <p class="font-bold text-sm text-dark">
-                        {review.testimonial_card_id.name}
-                      </p>
-                      <div class="stars">
-                        {[...Array(review.testimonial_card_id.rating)].map(
-                          (_, i) => (
-                            <svg class="w-4 h-4 fill-current" viewBox="0 0 24 24">
-                              <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
-                            </svg>
-                          )
-                        )}
-                      </div>
+              <div class="swiper-slide card flex h-auto flex-col min-h-[280px]">
+                <div class="flex items-center gap-4 mb-4">
+                  <div class="icon-chip-dark h-10 w-10 shrink-0 text-xl uppercase font-extrabold">
+                    {review.testimonial_card_id.name[0]}
+                  </div>
+                  <div>
+                    <p class="font-bold text-sm text-dark">
+                      {review.testimonial_card_id.name}
+                    </p>
+                    <div class="stars">
+                      {[...Array(review.testimonial_card_id.rating)].map(
+                        (_, i) => (
+                          <svg class="w-4 h-4 fill-current" viewBox="0 0 24 24">
+                            <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+                          </svg>
+                        )
+                      )}
                     </div>
                   </div>
-                  <p
-                    class="text-secondary leading-relaxed line-clamp-[7]"
-                    set:html={review.testimonial_card_id.content}
-                  />
                 </div>
+                <p
+                  class="text-secondary leading-relaxed line-clamp-[7]"
+                  set:html={review.testimonial_card_id.content}
+                />
               </div>
             ))
           }
@@ -63,6 +61,16 @@ const reviews = shuffleArray(cards);
     </div>
   </div>
 </section>
+
+<style is:global>
+  /* Equal-height testimonial cards: stretch every slide to the tallest */
+  .mySwiper .swiper-wrapper {
+    align-items: stretch;
+  }
+  .mySwiper .swiper-slide {
+    height: auto;
+  }
+</style>
 
 <script>
   import Swiper from "swiper";

--- a/src/components/sections/RichText.astro
+++ b/src/components/sections/RichText.astro
@@ -2,9 +2,11 @@
 const { item } = Astro.props;
 ---
 
-<div class={` custom-container pt-8 md:pb-12 pb-6 text-secondary prose`}>
-  <div
-    set:html={item?.content}
-    class=`mx-auto px-10 sm:px-14 space-y-5 text-[16px] ${item?.text_center ? "prose prose-headings:text-center prose-p:text-center prose-a:text-center" : ""}`
-  />
-</div>
+<section class="section-tight">
+  <div class="container-narrow">
+    <div
+      set:html={item?.content}
+      class={`prose-mibox space-y-5 text-[16px] ${item?.text_center ? "text-center prose-headings:text-center prose-p:text-center prose-a:text-center" : ""}`}
+    />
+  </div>
+</section>

--- a/src/components/sections/SingleHero.astro
+++ b/src/components/sections/SingleHero.astro
@@ -16,7 +16,7 @@ const formType = item?.form_type;
 ---
 
 <section
-  class="relative custom-container min-h-[450px] mt-6 rounded-xl overflow-hidden"
+  class="relative custom-container min-h-[450px] mt-6 overflow-hidden shadow-xl ring-1 ring-black/5"
 >
   <img
     src={bgImage}
@@ -25,16 +25,18 @@ const formType = item?.form_type;
       "Hero Background"}
     class="absolute inset-0 w-full h-full object-cover"
   />
-  <div class="absolute inset-0 gradient-overlay"></div>
+  <div class="absolute inset-0 overlay-grad"></div>
 
   <div
-    class="relative py-16 flex flex-col md:flex-row gap-8 justify-between items-center text-white z-10"
+    class="relative px-6 md:px-10 py-16 lg:py-20 flex flex-col md:flex-row gap-10 justify-between items-center text-white z-10"
   >
     <div class="md:w-1/2 w-full">
-      <h1 class="text-4xl md:text-5xl font-bold mb-4">{title}</h1>
+      <span class="eyebrow eyebrow-light mb-5">Moving &amp; Storage</span>
+      <h1 class="display text-white mt-5 mb-4">{title}</h1>
+      <span class="accent-bar"></span>
       {
         description && (
-          <p class="text-2xl font-bold whitespace-pre-wrap">{description}</p>
+          <p class="lead mt-5 max-w-xl text-white/90 whitespace-pre-wrap">{description}</p>
         )
       }
     </div>
@@ -42,7 +44,7 @@ const formType = item?.form_type;
     {
       formType === "quote_form" && (
         <div class="md:w-1/2 w-full flex justify-end">
-          <div class="w-full bg-white rounded-lg md:max-w-[450px] p-4 md:p-8">
+          <div class="w-full md:max-w-[450px] form-card">
             <QuoteForm
               client:only="svelte"
               quoteButtonTitle={quoteButtonTitle}
@@ -57,7 +59,7 @@ const formType = item?.form_type;
     {
       formType === "cold_form" && (
         <div class="md:w-1/2 w-full flex justify-end">
-          <div class="w-full bg-white rounded-lg md:max-w-[450px] p-4 md:p-8">
+          <div class="w-full md:max-w-[450px] form-card">
             <ColdStorageForm client:only="svelte" />
           </div>
         </div>
@@ -68,39 +70,21 @@ const formType = item?.form_type;
 
 {
   showStats && (
-    <div class="bg-[#E5EFFC] py-10 custom-container">
-      <h2 class="text-sm font-semibold uppercase tracking-wider text-secondary mb-10 text-center">
-        {SectionTitle}
-      </h2>
-      <div class="mx-auto px-4 grid grid-cols-1 sm:grid-cols-3 text-center gap-8">
-        {stats.map((stat) => (
-          <div class="flex flex-col lg:flex-row justify-center items-center gap-2">
-            <img src={stat.icon} alt={stat.label} class="w-8 h-8" />
-            <p class="text-xl font-bold text-gray-800">{stat.value}</p>
-            <p class="text-sm text-secondary">{stat.label}</p>
-          </div>
-        ))}
+    <div class="surface section-tight">
+      <div class="custom-container">
+        <h2 class="eyebrow mb-10 mx-auto w-fit">
+          {SectionTitle}
+        </h2>
+        <div class="mx-auto grid grid-cols-1 sm:grid-cols-3 text-center gap-8">
+          {stats.map((stat) => (
+            <div class="flex flex-col justify-center items-center gap-2">
+              <img src={stat.icon} alt={stat.label} class="w-8 h-8" />
+              <p class="stat-num">{stat.value}</p>
+              <p class="stat-label">{stat.label}</p>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   )
 }
-
-<style>
-  .gradient-overlay {
-    background: linear-gradient(
-      to bottom,
-      rgba(0, 0, 0, 0.5),
-      rgba(0, 0, 0, 0.1)
-    );
-  }
-
-  @media (min-width: 768px) {
-    .gradient-overlay {
-      background: linear-gradient(
-        to right,
-        rgba(0, 0, 0, 0.5),
-        rgba(0, 0, 0, 0.1)
-      );
-    }
-  }
-</style>

--- a/src/components/sections/Topbar.astro
+++ b/src/components/sections/Topbar.astro
@@ -6,9 +6,10 @@ const topbar = await getTopBar();
 
 {
   topbar.title && (
-    <div class="bg-yellow-300 py-3">
-      <div class="flex items-center custom-container text-black font-bold py-2">
-        <img src={Tag.src} class="mr-3 h-5" alt="Tag Icon" /> {topbar.title}
+    <div class="bg-primary">
+      <div class="custom-container flex items-center justify-center gap-3 py-2.5 text-center text-sm font-bold uppercase tracking-wide text-dark sm:text-[15px]">
+        <img src={Tag.src} class="h-5 w-5 shrink-0" alt="Tag Icon" />
+        <span>{topbar.title}</span>
       </div>
     </div>
   )

--- a/src/components/sections/TwoCol.astro
+++ b/src/components/sections/TwoCol.astro
@@ -8,37 +8,58 @@ const imagePlacement = item?.image_on_left ? "left" : "right";
 const button = item?.button || {};
 ---
 
-<div class="custom-container py-10 relative">
-  <div
-    class={`flex flex-col ${imagePlacement === "left" ? "lg:flex-row" : "lg:flex-row-reverse"} items-stretch`}
-  >
+<section class="section surface-cream">
+  <div class="custom-container relative">
     <div
-      class="w-full lg:w-1/2 p-8 flex justify-center items-start flex-col bg-background/10 prose-p:text-black/80 prose-a:text-primary"
+      class={`grid grid-cols-1 items-stretch gap-10 lg:grid-cols-2 lg:gap-16 ${imagePlacement === "left" ? "" : ""}`}
     >
+      <!-- Text column -->
       <div
-        class="mb-6 prose prose-td:border prose-th:border prose-td:px-2 prose-th:px-2"
-        set:html={item?.content}
-      />
-      {
-        button?.label && (
-          <div class="flex items-start justify-start">
-            <a
-              href={button?.link}
-              class="rounded-md bg-white px-4.5 py-2.5 text-sm font-semibold !text-black shadow-sm focus-visible:outline"
-            >
-              {button?.label}
-            </a>
-          </div>
-        )
-      }
-    </div>
+        class={`flex flex-col items-start justify-center ${imagePlacement === "left" ? "lg:order-2" : "lg:order-1"}`}
+      >
+        <span class="eyebrow">Portable Moving &amp; Storage</span>
+        <div class="accent-bar"></div>
+        <div
+          class="prose-mibox mt-6 prose-td:border prose-th:border prose-td:px-2 prose-th:px-2"
+          set:html={item?.content}
+        />
+        {
+          button?.label && (
+            <div class="mt-8">
+              <a href={button?.link} class="btn-primary btn-lg">
+                {button?.label}
+                <svg
+                  class="h-5 w-5"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M4 10h12m0 0l-5-5m5 5l-5 5"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </a>
+            </div>
+          )
+        }
+      </div>
 
-    <div class="w-full lg:w-1/2">
-      <img
-        src={getAssetURL(item?.image?.id)}
-        alt={item?.image?.description || item?.image?.title || "Featured Image"}
-        class="object-cover w-full h-full min-h-[200px]"
-      />
+      <!-- Image column -->
+      <div
+        class={`relative ${imagePlacement === "left" ? "lg:order-1" : "lg:order-2"}`}
+      >
+        <div class="card-flush h-full">
+          <img
+            src={getAssetURL(item?.image?.id)}
+            alt={item?.image?.description || item?.image?.title || "Featured Image"}
+            class="h-full min-h-[280px] w-full object-cover"
+          />
+        </div>
+      </div>
     </div>
   </div>
-</div>
+</section>

--- a/src/components/sections/WhyUS.astro
+++ b/src/components/sections/WhyUS.astro
@@ -5,56 +5,62 @@ const { item } = Astro.props;
 const { cards, title } = item;
 ---
 
-<section class="custom-container mx-auto px-4 relative py-10 lg:py-24">
-  <h2
-    class="text-4xl text-secondary lg:text-5xl text-center font-semibold mb-12"
-  >
-    {title}
-  </h2>
-  <div class="md:grid hidden md:grid-cols-3 divide-x gap-6">
-    {
-      cards.map((option) => (
-        <div class="text-center p-6 flex justify-center items-center flex-col">
-          <img
-            src={getAssetURL(option.why_us_card_id.image.id)}
-            alt={
-              option.why_us_card_id.image.description ||
-              option.why_us_card_id.image.title ||
-              "Why Us Image"
-            }
-            class={` mb-4  ${option.why_us_card_id.full_image ? "w-full h-[200px] rounded-lg object-cover " : "w-24 h-auto rounded-full mx-auto"} `}
-          />
-          <h2 class="text-xl font-bold mb-4">{option.why_us_card_id.title}</h2>
-          <div class="mb-6 prose text-start text-sm ">
-            {option.why_us_card_id.description}
-          </div>
-        </div>
-      ))
-    }
-  </div>
-  <div class="md:hidden block">
-    <div class="swiper storage-slider">
-      <div class="swiper-wrapper">
-        {
-          cards.map((option) => (
-            <div class=" swiper-slide text-center border p-6 rounded-lg shadow-md flex justify-between items-start flex-col">
-              <div>
-                <img
-                  src={getAssetURL(option.why_us_card_id.image)}
-                  alt={option.title}
-                  class={`mx-auto mb-4 rounded-full ${option.full_image ? "w-full h-[150px] object-cover " : "w-24 h-auto"} `}
-                />
-                <h2 class="text-xl font-bold mb-4">
-                  {option.why_us_card_id.title}
-                </h2>
+<section class="section surface">
+  <div class="custom-container relative">
+    <div class="section-head">
+      <span class="eyebrow">Why Choose Us</span>
+      <h2 class="heading-lg mt-5">{title}</h2>
+      <div class="accent-bar mx-auto"></div>
+    </div>
 
-                <div class="mb-6 prose text-start text-sm ">
-                  {option.why_us_card_id.description}
+    <div class="mt-14 hidden gap-6 md:grid md:grid-cols-3 lg:mt-16">
+      {
+        cards.map((option) => (
+          <div class="card card-hover flex flex-col items-center text-center">
+            <img
+              src={getAssetURL(option.why_us_card_id.image.id)}
+              alt={
+                option.why_us_card_id.image.description ||
+                option.why_us_card_id.image.title ||
+                "Why Us Image"
+              }
+              class={`mb-5 ${option.why_us_card_id.full_image ? "h-[200px] w-full object-cover" : "mx-auto h-24 w-auto object-contain"} `}
+            />
+            <h3 class="mb-3 text-xl font-bold tracking-tight text-dark">
+              {option.why_us_card_id.title}
+            </h3>
+            <div class="text-start text-sm leading-relaxed text-secondary">
+              {option.why_us_card_id.description}
+            </div>
+          </div>
+        ))
+      }
+    </div>
+
+    <div class="mt-14 block md:hidden lg:mt-16">
+      <div class="swiper storage-slider">
+        <div class="swiper-wrapper">
+          {
+            cards.map((option) => (
+              <div class="swiper-slide card flex flex-col items-stretch justify-between text-center">
+                <div>
+                  <img
+                    src={getAssetURL(option.why_us_card_id.image)}
+                    alt={option.title}
+                    class={`mx-auto mb-5 ${option.full_image ? "h-[150px] w-full object-cover" : "h-24 w-auto object-contain"} `}
+                  />
+                  <h3 class="mb-3 text-xl font-bold tracking-tight text-dark">
+                    {option.why_us_card_id.title}
+                  </h3>
+
+                  <div class="text-start text-sm leading-relaxed text-secondary">
+                    {option.why_us_card_id.description}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))
-        }
+            ))
+          }
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -1,22 +1,23 @@
 ---
 interface ButtonProps {
-  label: string;
+  label?: string;
+  title?: string;
   link?: string;
+  variant?: "primary" | "secondary" | "outline" | "white";
 }
-const { label, link }: ButtonProps = Astro.props as ButtonProps;
+const { label, title, link, variant = "primary" } = Astro.props as ButtonProps;
+const cls = `btn-${variant}`;
+const text = title ?? label;
 ---
 
 {
   link ? (
-    <a
-      href={link}
-      class="rounded-md bg-primary px-4.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-    >
-      <slot />
+    <a href={link} class={cls}>
+      <slot>{text}</slot>
     </a>
   ) : (
-    <button class="rounded-md bg-primary px-4.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
-      <slot />
+    <button class={cls}>
+      <slot>{text}</slot>
     </button>
   )
 }

--- a/src/components/ui/FeaturedImage.astro
+++ b/src/components/ui/FeaturedImage.astro
@@ -7,19 +7,24 @@ const { bg_image, content } = item;
 
 <section class="section">
   <div class="custom-container">
-    <div
-      class="relative flex justify-start items-start overflow-hidden p-8 md:p-14 text-white shadow-[0_24px_60px_-24px_rgba(16,20,30,0.4)] ring-1 ring-black/5"
-    >
-      <img
-        src={getAssetURL(bg_image.id)}
-        alt={bg_image.description || bg_image.title || "Background Image"}
-        class="absolute inset-0 w-full h-full object-cover -z-10"
-      />
-      <div class="overlay-grad -z-10"></div>
-      <div class="h-1 lg:w-2/5 hidden lg:block"></div>
-      <div class="lg:w-3/5 w-full">
-        <span class="accent-bar mb-6 mt-0"></span>
-        <div class="prose prose-invert max-w-none" set:html={content} />
+    <div class="grid items-stretch gap-10 lg:grid-cols-2 lg:gap-14">
+      <!-- Image column -->
+      <div
+        class="card-flush card-hover overflow-hidden order-1 lg:order-none"
+      >
+        <img
+          src={getAssetURL(bg_image.id)}
+          alt={bg_image.description || bg_image.title || "Featured Image"}
+          class="h-full w-full min-h-[280px] object-cover"
+          loading="lazy"
+          decoding="async"
+        />
+      </div>
+
+      <!-- Content column -->
+      <div class="order-2 flex flex-col justify-center lg:order-none">
+        <span class="accent-bar mt-0 mb-6"></span>
+        <div class="prose-mibox max-w-none" set:html={content} />
       </div>
     </div>
   </div>

--- a/src/components/ui/FeaturedImage.astro
+++ b/src/components/ui/FeaturedImage.astro
@@ -24,7 +24,10 @@ const { bg_image, content } = item;
       <!-- Content column -->
       <div class="order-2 flex flex-col justify-center lg:order-none">
         <span class="accent-bar mt-0 mb-6"></span>
-        <div class="prose-mibox max-w-none" set:html={content} />
+        <div
+          class="prose-mibox max-w-none prose-p:text-dark prose-li:text-dark prose-strong:text-dark"
+          set:html={content}
+        />
       </div>
     </div>
   </div>

--- a/src/components/ui/FeaturedImage.astro
+++ b/src/components/ui/FeaturedImage.astro
@@ -5,18 +5,22 @@ const { item } = Astro.props;
 const { bg_image, content } = item;
 ---
 
-<section class="py-8 md:py-12">
-  <div
-    class="relative flex justify-start items-start p-6 md:p-12 text-white overflow-hidden"
-  >
-    <img
-      src={getAssetURL(bg_image.id)}
-      alt={bg_image.description || bg_image.title || "Background Image"}
-      class="absolute inset-0 w-full h-full object-cover -z-10 brightness-[0.3]"
-    />
-    <div class="h-1 lg:w-2/5 hidden lg:block"></div>
-    <div class="lg:w-3/5 w-full">
-      <div class="prose prose-invert max-w-none" set:html={content} />
+<section class="section">
+  <div class="custom-container">
+    <div
+      class="relative flex justify-start items-start overflow-hidden p-8 md:p-14 text-white shadow-[0_24px_60px_-24px_rgba(16,20,30,0.4)] ring-1 ring-black/5"
+    >
+      <img
+        src={getAssetURL(bg_image.id)}
+        alt={bg_image.description || bg_image.title || "Background Image"}
+        class="absolute inset-0 w-full h-full object-cover -z-10"
+      />
+      <div class="overlay-grad -z-10"></div>
+      <div class="h-1 lg:w-2/5 hidden lg:block"></div>
+      <div class="lg:w-3/5 w-full">
+        <span class="accent-bar mb-6 mt-0"></span>
+        <div class="prose prose-invert max-w-none" set:html={content} />
+      </div>
     </div>
   </div>
 </section>

--- a/src/components/ui/Modal.svelte
+++ b/src/components/ui/Modal.svelte
@@ -12,10 +12,10 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="fixed inset-0 bg-black/80 z-[9999999999] flex items-center justify-center"
+    class="fixed inset-0 bg-ink/70 z-[9999999999] flex items-center justify-center p-4"
     on:click={handleBackdropClick}
   >
-    <div class="bg-white p-6 rounded-lg shadow-xl max-w-md w-full mx-4">
+    <div class="bg-white p-6 shadow-2xl ring-1 ring-black/5 max-w-md w-full">
       <div class="space-y-4">
         <slot />
       </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,4 +1,4 @@
-import { defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 import { glob } from "astro/loaders";
 
 const pages = defineCollection({
@@ -14,4 +14,26 @@ const reviews = defineCollection({
 const singletons = defineCollection({
   loader: glob({ pattern: "*.yaml", base: "src/data/singletons" }),
 });
-export const collections = { pages, blogs, reviews, singletons };
+
+const locations = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "src/data/locations" }),
+  schema: z.object({
+    title: z.string(), // SEO <title>
+    city: z.string(),
+    state: z.string().default("FL"),
+    region: z.string().default("Gulf Coast"),
+    metaDescription: z.string(),
+    heroHeading: z.string(),
+    heroSubheading: z.string().optional(),
+    intro: z.string(),
+    // Optional list of nearby neighborhoods / areas served
+    neighborhoods: z.array(z.string()).default([]),
+    // Optional highlight stats: { value, label }
+    highlights: z
+      .array(z.object({ value: z.string(), label: z.string() }))
+      .default([]),
+    order: z.number().default(0),
+  }),
+});
+
+export const collections = { pages, blogs, reviews, singletons, locations };

--- a/src/data/locations/bradenton.md
+++ b/src/data/locations/bradenton.md
@@ -1,0 +1,66 @@
+---
+title: "Portable Moving & Storage Containers in Bradenton, FL | MI-BOX"
+city: "Bradenton"
+state: "FL"
+region: "Gulf Coast"
+metaDescription: "Local portable moving and storage containers in Bradenton, FL, delivered to your door. Weather-tight, ground-level loading, flexible month-to-month rentals."
+heroHeading: "Moving & Storage Containers in Bradenton"
+heroSubheading: "Your hometown portable container company, delivering door-to-door across Bradenton."
+intro: "MI-BOX is based right here in Bradenton, delivering weather-tight portable moving and storage containers to homes and businesses throughout the city. Load on your own schedule and let our local crew handle the heavy delivery and hauling."
+neighborhoods:
+  - "Downtown Bradenton"
+  - "West Bradenton"
+  - "Riverwalk"
+  - "Cortez"
+  - "Bayshore Gardens"
+  - "Anna Maria Island"
+  - "Palma Sola"
+  - "Village of the Arts"
+highlights:
+  - value: "Same-Day"
+    label: "Delivery available"
+  - value: "16'"
+    label: "& 8' container sizes"
+  - value: "Month-to-Month"
+    label: "Flexible rentals"
+  - value: "Hometown"
+    label: "Bradenton-based team"
+order: 2
+---
+
+## Portable Storage & Moving in Bradenton
+
+Bradenton is home base for MI-BOX, so when you order a container here you are working with neighbors, not a national call center. From the Riverwalk and the Village of the Arts to the fishing village of Cortez and the beaches of Anna Maria Island, we deliver weather-tight portable containers right to your driveway. Our level-lift delivery system sets each unit down gently at ground level so loading is easy and ramp-free.
+
+Because we are local, scheduling is simple and delivery is fast, often same-day. You load on your own time, lock the rollup door, and we take it from there.
+
+## Why Bradenton chooses MI-BOX
+
+Living along the Manatee River and so close to the Gulf means storms and humidity are facts of life. Every MI-BOX container is built weather-tight with a secure, lockable rollup door to protect what is inside. Ground-level loading keeps the strain off your back, whether you are handling boxes, appliances, or boat gear.
+
+Bradenton neighbors rely on MI-BOX for:
+
+- Moving across town or out of state without renting a truck
+- Storing belongings during a home remodel or addition
+- Decluttering before listing or after downsizing
+- Holding inventory for local shops and contractors
+- Staging a home for the market
+- Protecting furnishings during hurricane prep
+
+Learn more about our full lineup on our [moving services](/moving-services) and [storage services](/storage-services) pages.
+
+Choosing a size is easy. An 8-foot container handles a room, a garage cleanout, or a staging project, while a 16-foot container comfortably holds the contents of a typical home for a local or long-distance move. Since we rent month-to-month, you keep the container exactly as long as the job takes and not a day longer.
+
+## Cold storage containers in Bradenton
+
+Restaurants, seafood markets near Cortez, caterers, and event hosts can add refrigerated capacity fast with our [cold storage containers](/cold-storage-containers). They are perfect for backup cooling during equipment failures, big events, or storm season when reliable refrigeration matters most.
+
+## How it works
+
+MI-BOX makes moving and storage in Bradenton straightforward:
+
+1. We deliver a clean, weather-tight container to your home or business with our level-lift system.
+2. You load it at ground level, on your own schedule, and lock it up.
+3. We store it at our secure local facility, leave it on-site, or move it to your destination.
+
+We are right around the corner at 6510 3rd Ave W in Bradenton. Call our team at [(941) 777-7269](tel:19417777269), browse our [service areas](/service-areas), or [contact us](/contact-us) to reserve your container today.

--- a/src/data/locations/lakewood-ranch.md
+++ b/src/data/locations/lakewood-ranch.md
@@ -1,0 +1,66 @@
+---
+title: "Portable Moving & Storage Containers in Lakewood Ranch, FL | MI-BOX"
+city: "Lakewood Ranch"
+state: "FL"
+region: "Gulf Coast"
+metaDescription: "Portable moving and storage containers delivered in Lakewood Ranch, FL. Weather-tight, ground-level loading, flexible rentals, great for new builds and growing homes."
+heroHeading: "Moving & Storage Containers in Lakewood Ranch"
+heroSubheading: "Portable containers built for new builds, moves, and growing households in Lakewood Ranch."
+intro: "MI-BOX delivers weather-tight portable moving and storage containers throughout Lakewood Ranch, supporting new-home moves, renovations, and the constant growth of this master-planned community. Load on your schedule and we handle the rest."
+neighborhoods:
+  - "Lakewood Ranch Main Street"
+  - "Waterside Place"
+  - "Lakewood Ranch Country Club"
+  - "Greenbrook"
+  - "Summerfield"
+  - "Mallory Park"
+  - "Esplanade"
+  - "Del Webb"
+highlights:
+  - value: "Same-Week"
+    label: "Delivery available"
+  - value: "16'"
+    label: "& 8' container sizes"
+  - value: "New-Build"
+    label: "Ready for fresh moves"
+  - value: "Local"
+    label: "Bradenton-based team"
+order: 4
+---
+
+## Portable Storage & Moving in Lakewood Ranch
+
+Lakewood Ranch is one of the fastest-growing master-planned communities in the country, with new neighborhoods rising from Waterside Place to Del Webb and beyond. All that growth means a lot of moving, building, and settling in, and MI-BOX makes each of those easier. We deliver portable containers right to your homesite or driveway, setting them gently at ground level with our level-lift system so loading is simple.
+
+Whether you are closing on a brand-new home, furnishing a model, or organizing a household during construction, you load on your own timeline. When you are ready, we store the container or move it for you.
+
+## Why Lakewood Ranch chooses MI-BOX
+
+With new builds and busy households comes the need for flexible, secure space. Every MI-BOX container is weather-tight with a lockable rollup door, protecting furnishings, appliances, and finishes from Florida humidity and sudden storms. Ground-level loading is ideal when crews and homeowners are moving in and out throughout a project.
+
+Lakewood Ranch residents and builders use MI-BOX for:
+
+- Moving into a new home without a rental truck
+- Storing furniture during construction or punch-list work
+- Holding finishes, fixtures, and materials on-site
+- Decluttering and staging for a quick sale
+- Renovations and additions on established homes
+- Overflow storage for home-based businesses
+
+Explore our full options on our [moving services](/moving-services) and [storage services](/storage-services) pages.
+
+Picking a size is easy. An 8-foot container suits a single room, a garage, or a staging project, while a 16-foot container handles a full new-home move or a major renovation. Month-to-month terms work well for new construction timelines that can shift, so you are never locked into paying for space after your move-in or project wraps up.
+
+## Cold storage containers in Lakewood Ranch
+
+The restaurants, markets, and event venues around Main Street and Waterside can add refrigerated capacity fast with our [cold storage containers](/cold-storage-containers). They are a dependable solution for community events, seasonal demand, and cooling backup during equipment outages or storms.
+
+## How it works
+
+MI-BOX keeps moving and storage in Lakewood Ranch simple:
+
+1. We deliver a clean, weather-tight container to your home or jobsite with our level-lift system.
+2. You load it at ground level, on your own schedule, and lock it securely.
+3. We store it at our secure facility, keep it on-site, or move it to your new address.
+
+Building, buying, or moving in Lakewood Ranch? Call our [Bradenton-based team](/service-areas) at [(941) 777-7269](tel:19417777269) or [contact us](/contact-us) for same-week delivery and flexible terms.

--- a/src/data/locations/palmetto.md
+++ b/src/data/locations/palmetto.md
@@ -1,0 +1,66 @@
+---
+title: "Portable Moving & Storage Containers in Palmetto, FL | MI-BOX"
+city: "Palmetto"
+state: "FL"
+region: "Gulf Coast"
+metaDescription: "Portable moving and storage containers delivered in Palmetto and Ellenton, FL. Weather-tight, ground-level loading, flexible month-to-month rentals from a local team."
+heroHeading: "Moving & Storage Containers in Palmetto"
+heroSubheading: "Riverside-friendly portable containers serving Palmetto, Ellenton, and the outlet area."
+intro: "MI-BOX delivers weather-tight portable moving and storage containers throughout Palmetto and Ellenton, from riverside neighborhoods to the busy outlet corridor. Load on your own schedule and let our local crew store or move it for you."
+neighborhoods:
+  - "Downtown Palmetto"
+  - "Ellenton"
+  - "Riverside"
+  - "Terra Ceia"
+  - "Memphis"
+  - "Rubonia"
+  - "Snead Island"
+  - "Ellenton Premium Outlets area"
+highlights:
+  - value: "Same-Week"
+    label: "Delivery available"
+  - value: "16'"
+    label: "& 8' container sizes"
+  - value: "Month-to-Month"
+    label: "Flexible rentals"
+  - value: "Local"
+    label: "Bradenton-based team"
+order: 5
+---
+
+## Portable Storage & Moving in Palmetto
+
+Palmetto sits right along the Manatee River, with neighboring Ellenton, the popular Premium Outlets, and quiet riverside spots like Snead Island and Terra Ceia close by. MI-BOX delivers portable containers throughout the area, dropping each one gently at ground level with our level-lift system. There is no truck ramp to wrestle with and no deadline forcing you to rush a load.
+
+From a downtown Palmetto bungalow to a riverside property in Ellenton, you load on your own time. When you finish, we store the container at our secure facility, leave it on-site, or move it wherever you need it.
+
+## Why Palmetto chooses MI-BOX
+
+Riverside living and the Gulf Coast climate make weather-tight storage a must. Every MI-BOX container seals tight against rain and humidity and locks with a secure rollup door, keeping your belongings protected. Ground-level loading is a welcome difference when you are handling furniture, tools, or fishing and boating gear on your own.
+
+Palmetto and Ellenton neighbors turn to MI-BOX for:
+
+- Moving across town or out of state without renting a truck
+- Storing belongings during a renovation or river-home repair
+- Decluttering before listing a property
+- Holding inventory for outlet-area shops and small businesses
+- Staging homes for sale
+- Protecting furnishings during hurricane season
+
+See the full picture on our [moving services](/moving-services) and [storage services](/storage-services) pages.
+
+Choosing a size is straightforward. The 8-foot container is right for a room, a garage cleanout, or a small business overflow, while the 16-foot container holds a full household for a move. Because we rent month-to-month, you keep the container only as long as your project or move requires, with no long-term commitment.
+
+## Cold storage containers in Palmetto
+
+Restaurants, caterers, markets, and event hosts near the outlets and along the river can add refrigerated space quickly with our [cold storage containers](/cold-storage-containers). They are a reliable backup for cooling outages, seasonal demand, and storm-season planning.
+
+## How it works
+
+MI-BOX makes moving and storage in Palmetto easy:
+
+1. We deliver a clean, weather-tight container to your address using our level-lift system.
+2. You load it at ground level, on your own schedule, and lock it.
+3. We store it at our secure facility, keep it on-site, or move it to your destination.
+
+Planning a move or need extra space in Palmetto or Ellenton? Call our [Bradenton-based team](/service-areas) at [(941) 777-7269](tel:19417777269) or [contact us](/contact-us) for same-week delivery and flexible month-to-month terms.

--- a/src/data/locations/sarasota.md
+++ b/src/data/locations/sarasota.md
@@ -1,0 +1,66 @@
+---
+title: "Portable Moving & Storage Containers in Sarasota, FL | MI-BOX"
+city: "Sarasota"
+state: "FL"
+region: "Gulf Coast"
+metaDescription: "Portable moving and storage containers delivered to your door in Sarasota, FL. Weather-tight, ground-level loading, month-to-month rentals from a local team."
+heroHeading: "Moving & Storage Containers in Sarasota"
+heroSubheading: "Door-to-door portable containers for moving, storage, and renovations across Sarasota."
+intro: "MI-BOX brings weather-tight portable storage and moving containers right to your driveway in Sarasota, so you can load on your own schedule and skip the rental truck. We deliver, you load, and we store or move it for you."
+neighborhoods:
+  - "Downtown Sarasota"
+  - "Siesta Key"
+  - "Lido Key"
+  - "Gulf Gate"
+  - "Palmer Ranch"
+  - "Bird Key"
+  - "Southside Village"
+  - "Fruitville"
+highlights:
+  - value: "Same-Week"
+    label: "Delivery available"
+  - value: "16'"
+    label: "& 8' container sizes"
+  - value: "Month-to-Month"
+    label: "Flexible rentals"
+  - value: "Local"
+    label: "Bradenton-based team"
+order: 1
+---
+
+## Portable Storage & Moving in Sarasota
+
+Sarasota life moves between the arts district, the boutiques of St. Armands Circle, and the white sand of Siesta Key, and your moving and storage should be just as flexible. With MI-BOX, a sturdy container arrives at your home or business on our level-lift delivery system, settles gently at ground level, and waits as long as you need. There is no awkward truck ramp and no rush to return rented equipment by a deadline.
+
+Whether you are relocating to a condo downtown, downsizing from a single-family home in Palmer Ranch, or clearing space before a seasonal trip, you load at your own pace. When you are done, we can keep the container on your property, haul it to our secure facility, or move it across town.
+
+## Why Sarasota chooses MI-BOX
+
+Coastal weather is part of the deal here, so every MI-BOX container is weather-tight with a lockable rollup door to keep your belongings dry and secure. Ground-level loading means no lifting boxes shoulder-high, which matters when you are moving artwork, furniture, or gallery inventory.
+
+People across Sarasota use MI-BOX for:
+
+- Local and long-distance moves without a rental truck
+- Home renovations and flooring projects that need a clear room
+- Decluttering before listing a home for sale
+- Business and retail inventory overflow
+- Staging furniture during showings
+- Seasonal storage for snowbirds and second homes
+
+Because we are a locally owned [Bradenton-based team](/service-areas), you get real people who know the area, not a faceless national hotline.
+
+Most Sarasota households choose between our 8-foot container for a single room, garage, or staging project and our 16-foot container for a full home move or larger renovation. Not sure which fits? Our local team will walk you through it and help you pick the right size and term for the job, with no pressure and no long-term contract required.
+
+## Cold storage containers in Sarasota
+
+Sarasota's restaurants, caterers, event venues, and grocers sometimes need refrigerated space on short notice. Our [cold storage containers](/cold-storage-containers) deliver temperature-controlled capacity right where you need it, ideal for hurricane season backup, special events, or covering a walk-in cooler outage.
+
+## How it works
+
+Getting started with MI-BOX in Sarasota takes three simple steps:
+
+1. We deliver a clean, weather-tight container to your address with our level-lift system.
+2. You load it on your own timeline, ground-level and lockable.
+3. We store it at our secure facility, keep it on-site, or move it wherever you are headed.
+
+Ready to clear space or plan a move? Explore our [moving services](/moving-services) and [storage services](/storage-services), or call our Sarasota-area team at [(941) 777-7269](tel:19417777269). You can also [contact us](/contact-us) for a quick quote and same-week availability.

--- a/src/data/locations/venice.md
+++ b/src/data/locations/venice.md
@@ -1,0 +1,66 @@
+---
+title: "Portable Moving & Storage Containers in Venice, FL | MI-BOX"
+city: "Venice"
+state: "FL"
+region: "Gulf Coast"
+metaDescription: "Portable moving and storage containers delivered in Venice, FL. Weather-tight, ground-level loading, month-to-month rentals, ideal for snowbirds and seasonal moves."
+heroHeading: "Moving & Storage Containers in Venice"
+heroSubheading: "Flexible portable containers delivered across Venice and its island beaches."
+intro: "MI-BOX delivers weather-tight portable moving and storage containers throughout Venice, from the island downtown to the beaches and the snowbird communities inland. Load on your schedule and we will store it or move it for you."
+neighborhoods:
+  - "Venice Island"
+  - "Venice Beach"
+  - "Caspersen Beach"
+  - "Nokomis"
+  - "Laurel"
+  - "South Venice"
+  - "Venice Gardens"
+  - "Jacaranda"
+highlights:
+  - value: "Same-Week"
+    label: "Delivery available"
+  - value: "16'"
+    label: "& 8' container sizes"
+  - value: "Seasonal"
+    label: "Snowbird-friendly terms"
+  - value: "Local"
+    label: "Bradenton-based team"
+order: 3
+---
+
+## Portable Storage & Moving in Venice
+
+Venice has a rhythm all its own, from the historic island downtown and the shark-tooth sands of Caspersen Beach to the quiet seasonal neighborhoods of South Venice and Nokomis. MI-BOX fits that rhythm with portable containers delivered straight to your door. Our level-lift system places each unit gently at ground level, so there is no truck ramp and no rush.
+
+Many Venice residents split their year between here and somewhere up north, and MI-BOX is built for exactly that. Load at your own pace before you head out, lock the rollup door, and let us store your belongings until you return.
+
+## Why Venice chooses MI-BOX
+
+Salt air, summer storms, and long stretches of an empty seasonal home all call for storage you can trust. Every MI-BOX container is weather-tight with a lockable rollup door, keeping your furniture and seasonal gear dry and secure. Ground-level loading is a relief when you are handling everything yourself.
+
+Venice neighbors choose MI-BOX for:
+
+- Snowbird storage between seasons
+- Moving to or from a condo or villa without a rental truck
+- Clearing rooms during a remodel or re-flooring
+- Decluttering before selling
+- Storing patio, beach, and boating gear
+- Holding furnishings during showings and staging
+
+See how it all works on our [moving services](/moving-services) and [storage services](/storage-services) pages.
+
+Sizing is simple in Venice. The 8-foot container is perfect for a villa, a seasonal closet, or a single room of furniture, while the 16-foot container fits a full home move. With month-to-month terms, snowbirds can store for the off-season and pick right back up when they return, paying only for the time they actually need.
+
+## Cold storage containers in Venice
+
+Venice's restaurants, beachside caterers, and event venues can scale up refrigeration in a hurry with our [cold storage containers](/cold-storage-containers). They are a smart safeguard for special events, seasonal demand, and hurricane-season cooling backup.
+
+## How it works
+
+Renting with MI-BOX in Venice is easy:
+
+1. We deliver a clean, weather-tight container to your address using our level-lift system.
+2. You load it at ground level, on your own timeline, and lock it.
+3. We store it at our secure facility, leave it on-site, or move it to your next stop.
+
+Heading north for the summer or planning a move? Call our team at [(941) 777-7269](tel:19417777269), check our [service areas](/service-areas), or [contact us](/contact-us) to lock in your dates and pricing.

--- a/src/pages/locations/[slug].astro
+++ b/src/pages/locations/[slug].astro
@@ -1,0 +1,155 @@
+---
+import Layout from "@layouts/Layout.astro";
+import QuoteForm from "@components/forms/QuoteForm.svelte";
+import { getCollection, getEntry, render } from "astro:content";
+import { getGlobal } from "src/lib/getPageData";
+import heroFallback from "@assets/images/service-areas/blocks/0/value/bgImage.jpg";
+
+const { slug } = Astro.params;
+const safeSlug = typeof slug === "string" ? slug : "";
+
+const entry = await getEntry("locations", safeSlug);
+if (!entry) {
+  return new Response("Location not found", { status: 404 });
+}
+
+const { Content } = await render(entry);
+const data = entry.data;
+
+// Other locations for cross-linking
+const all = await getCollection("locations");
+const others = all
+  .filter((l) => l.id !== entry.id)
+  .sort((a, b) => a.data.order - b.data.order);
+
+const global = await getGlobal();
+const placeLabel = `${data.city}, ${data.state}`;
+---
+
+<Layout
+  title={data.title}
+  description={data.metaDescription}
+  ogImage=""
+  pageUrl={`/locations/${safeSlug}`}
+>
+  <!-- Hero -->
+  <section class="relative bg-ink">
+    <img
+      src={heroFallback.src}
+      alt={`MI-BOX moving and storage in ${placeLabel}`}
+      class="absolute inset-0 h-full w-full object-cover opacity-60"
+      loading="eager"
+    />
+    <div class="overlay-grad"></div>
+    <div class="custom-container relative">
+      <div class="max-w-2xl py-20 lg:py-28">
+        <span class="eyebrow eyebrow-light mb-5">{data.region} • {placeLabel}</span>
+        <h1 class="display text-white">{data.heroHeading}</h1>
+        <div class="accent-bar"></div>
+        {
+          data.heroSubheading && (
+            <p class="lead mt-6 text-white/90">{data.heroSubheading}</p>
+          )
+        }
+        <div class="mt-8 flex flex-wrap gap-3">
+          <a href="#quote" class="btn-primary btn-lg">Get a Free Quote</a>
+          {
+            global?.phone_number && (
+              <a
+                href={`tel:${global.phone_number}`}
+                class="btn-ghost-light btn-lg"
+              >
+                Call {global.phone_number}
+              </a>
+            )
+          }
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Highlights -->
+  {
+    data.highlights.length > 0 && (
+      <section class="surface section-tight">
+        <div class="custom-container">
+          <div class="grid grid-cols-2 gap-8 text-center md:grid-cols-4">
+            {data.highlights.map((h) => (
+              <div>
+                <p class="stat-num">{h.value}</p>
+                <p class="stat-label">{h.label}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  <!-- Body + sticky quote form -->
+  <section class="section">
+    <div class="custom-container grid gap-12 lg:grid-cols-[1fr_minmax(360px,420px)] lg:gap-16">
+      <div>
+        <span class="eyebrow">Serving {data.city}</span>
+        <p class="lead mt-5 text-secondary">{data.intro}</p>
+        <div class="accent-bar"></div>
+        <div class="prose-mibox mt-8 max-w-none">
+          <Content />
+        </div>
+
+        {
+          data.neighborhoods.length > 0 && (
+            <div class="mt-10">
+              <h2 class="heading-md">Areas we serve near {data.city}</h2>
+              <div class="mt-5 flex flex-wrap gap-2.5">
+                {data.neighborhoods.map((n) => (
+                  <span class="chip">{n}</span>
+                ))}
+              </div>
+            </div>
+          )
+        }
+      </div>
+
+      <!-- Quote form -->
+      <aside class="lg:sticky lg:top-28 lg:self-start" id="quote">
+        <div class="form-card">
+          <QuoteForm
+            client:only="svelte"
+            quoteFormTitle={`Get a Quote in ${data.city}`}
+            quoteButtonTitle="Get My Free Quote"
+            phoneNumber={global?.phone_number}
+            promoCode={global?.promo_code}
+          />
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <!-- Other locations -->
+  {
+    others.length > 0 && (
+      <section class="section-dark section">
+        <div class="custom-container">
+          <div class="section-head !text-left">
+            <span class="eyebrow eyebrow-light">More Gulf Coast locations</span>
+            <h2 class="heading-lg mt-5 text-white">We deliver across the Gulf Coast</h2>
+          </div>
+          <div class="mt-10 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+            {others.map((l) => (
+              <a
+                href={`/locations/${l.id}`}
+                class="group flex items-center justify-between border border-white/15 bg-white/5 px-5 py-4 transition-colors hover:border-primary hover:bg-white/10"
+              >
+                <span class="font-bold text-white">{l.data.city}</span>
+                <span class="text-primary transition-transform group-hover:translate-x-1">
+                  →
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+    )
+  }
+</Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,19 +1,155 @@
 @import "tailwindcss";
 
 @plugin "@tailwindcss/typography";
+
+/* =====================================================================
+   MI-BOX Moving & Storage — design system
+   Brand: MI-BOX yellow (#FFC20E) + charcoal/ink. Neutrals via Tailwind
+   gray-*. Yellow = bold accents/CTAs (always on dark text). Charcoal/ink
+   = headings, dark banners, secondary actions. Industrial, square,
+   balanced — zero border radius everywhere.
+   ===================================================================== */
 @theme {
-  --color-primary: #009ad6;
-  --color-secondary: #4d4d4d;
-  --color-background: #0069e5;
-}
-.custom-container {
-  @apply lg:max-w-[1100px] xl:max-w-[1380px] mx-auto  max-w-full px-8;
-}
-.date-time-field #delivery-date {
-  width: 100% !important;
-  padding: 0.75rem !important;
+  --color-primary: #ffc20e;        /* MI-BOX yellow */
+  --color-primary-dark: #e8a900;   /* hover / pressed */
+  --color-primary-light: #ffd75e;
+  --color-primary-soft: #fff7df;   /* yellow tint surface */
+  --color-dark: #1c1c1c;           /* charcoal — headings */
+  --color-ink: #121417;            /* near-black — banners/footer */
+  --color-charcoal: #2a2a2a;
+  --color-secondary: #4b5563;      /* body copy (gray-600) */
+  --color-muted: #6b7280;
+  --color-cream: #faf8f2;
+  --color-surface: #f6f7f9;        /* soft gray section bg */
+  --color-line: #e7e9ee;
+  --color-success: #16a34a;
+  --color-background: #f6f7f9;      /* legacy alias */
+
+  /* Sharp, industrial look — zero radius everywhere */
+  --radius-xs: 0px;
+  --radius-sm: 0px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --radius-xl: 0px;
+  --radius-2xl: 0px;
+  --radius-3xl: 0px;
+  --radius-4xl: 0px;
 }
 
-html {
-  scroll-behavior: smooth;
+@layer base {
+  body { @apply text-secondary antialiased; }
+  h1, h2, h3, h4, h5 {
+    @apply font-extrabold tracking-tight text-dark;
+    text-wrap: balance;
+  }
+  p { text-wrap: pretty; }
+  a { @apply transition-colors duration-200; }
+  ::selection { @apply bg-primary text-dark; }
+  :target { scroll-margin-top: 7rem; }
 }
+
+@layer components {
+  /* ---- Layout ---- */
+  .custom-container { @apply mx-auto w-full max-w-[1320px] px-5 sm:px-8; }
+  .container-narrow { @apply mx-auto w-full max-w-3xl px-5 sm:px-8; }
+  .section { @apply py-16 lg:py-24; }
+  .section-tight { @apply py-12 lg:py-16; }
+  .surface { @apply bg-surface; }
+  .surface-cream { @apply bg-cream; }
+  .section-dark { @apply bg-ink text-gray-300; }
+
+  /* ---- Eyebrow / kicker ---- */
+  .eyebrow {
+    @apply inline-flex items-center gap-2 bg-primary/15 px-3.5 py-1.5
+           text-xs font-bold uppercase tracking-[0.14em] text-dark;
+  }
+  .eyebrow::before { content: ""; @apply h-1.5 w-1.5 bg-primary; }
+  .eyebrow-light { @apply bg-white/10 text-white; }
+  .eyebrow-light::before { @apply bg-primary; }
+
+  /* ---- Headings ---- */
+  .display    { @apply text-[2.6rem] font-extrabold leading-[1.02] tracking-tight text-dark sm:text-5xl lg:text-[4rem]; }
+  .heading-xl { @apply text-4xl font-extrabold leading-[1.05] tracking-tight text-dark md:text-5xl lg:text-[3.25rem]; }
+  .heading-lg { @apply text-3xl font-extrabold leading-[1.1] tracking-tight text-dark md:text-4xl lg:text-[2.6rem]; }
+  .heading-md { @apply text-2xl font-bold tracking-tight text-dark md:text-3xl; }
+  .lead       { @apply text-lg leading-relaxed text-secondary md:text-xl; }
+  .accent-bar { @apply mt-5 h-1.5 w-16 bg-primary; }
+
+  /* Centered section intro helper */
+  .section-head { @apply mx-auto max-w-2xl text-center; }
+
+  /* ---- Buttons ---- */
+  .btn, .btn-primary, .btn-secondary, .btn-outline, .btn-ghost-light, .btn-white {
+    @apply inline-flex cursor-pointer items-center justify-center gap-2 px-6 py-3.5
+           text-base font-bold leading-none transition-all duration-200
+           focus:outline-none focus-visible:ring-4 focus-visible:ring-primary/40;
+  }
+  .btn-primary   { @apply bg-primary text-dark shadow-lg shadow-primary/30 hover:bg-primary-dark hover:-translate-y-0.5 hover:shadow-xl active:translate-y-0; }
+  .btn-secondary { @apply bg-dark text-white shadow-lg shadow-black/20 hover:bg-charcoal hover:-translate-y-0.5 active:translate-y-0; }
+  .btn-outline   { @apply border-2 border-dark/15 bg-white text-dark hover:border-dark hover:-translate-y-0.5; }
+  .btn-white     { @apply bg-white text-dark shadow-lg hover:bg-gray-100 hover:-translate-y-0.5; }
+  .btn-ghost-light { @apply border-2 border-white/25 bg-white/5 text-white backdrop-blur hover:border-primary hover:text-primary; }
+  .btn-lg { @apply px-8 py-4 text-lg; }
+  .btn-sm { @apply px-4 py-2.5 text-sm; }
+  .btn-block { @apply w-full; }
+
+  /* ---- Badges / chips ---- */
+  .badge { @apply inline-flex items-center gap-1.5 bg-primary px-3 py-1 text-xs font-extrabold uppercase tracking-wide text-dark; }
+  .badge-soft { @apply inline-flex items-center gap-1.5 bg-primary-soft px-3 py-1 text-xs font-bold text-dark ring-1 ring-primary/30; }
+  .chip { @apply inline-flex items-center gap-1.5 bg-gray-100 px-3 py-1 text-sm font-semibold text-dark; }
+
+  /* Square icon chip holding an svg/img */
+  .icon-chip { @apply inline-flex h-12 w-12 items-center justify-center bg-primary/15 text-dark; }
+  .icon-chip-dark { @apply inline-flex h-12 w-12 items-center justify-center bg-primary text-dark; }
+
+  /* ---- Cards ---- */
+  .card { @apply bg-white p-6 shadow-[0_4px_24px_-10px_rgba(16,20,30,0.14)] ring-1 ring-black/5 transition-all duration-300; }
+  .card-hover { @apply hover:-translate-y-1.5 hover:shadow-[0_22px_48px_-18px_rgba(16,20,30,0.3)]; }
+  .card-flush { @apply overflow-hidden bg-white shadow-[0_4px_24px_-10px_rgba(16,20,30,0.14)] ring-1 ring-black/5 transition-all duration-300; }
+
+  /* ---- Stats ---- */
+  .stat-num { @apply text-4xl font-extrabold tracking-tight text-dark md:text-5xl; }
+  .stat-label { @apply mt-1 text-sm font-medium text-muted; }
+
+  /* ---- Forms ---- */
+  .form-card { @apply bg-white p-6 shadow-2xl ring-1 ring-black/5 sm:p-7; }
+  .field { @apply flex flex-col gap-1.5; }
+  .label { @apply text-sm font-semibold text-dark; }
+  .input, .form-input, .select {
+    @apply w-full border border-line bg-white px-4 py-3 text-[15px] text-dark
+           placeholder:text-muted transition-shadow
+           focus:border-primary focus:outline-none focus:ring-4 focus:ring-primary/25;
+  }
+  .form-help { @apply text-xs text-muted; }
+  .form-error { @apply text-xs font-medium text-red-600; }
+
+  /* ---- Trust row ---- */
+  .stars { @apply inline-flex items-center text-primary; }
+  .trust-row { @apply flex flex-wrap items-center gap-x-6 gap-y-3 text-sm font-medium; }
+
+  /* ---- Nav ---- */
+  .nav-link { @apply relative text-[15px] font-semibold text-dark transition-colors hover:text-primary-dark; }
+  .nav-link::after {
+    content: ""; @apply absolute -bottom-1.5 left-0 h-0.5 w-0 bg-primary transition-all duration-300;
+  }
+  .nav-link:hover::after { @apply w-full; }
+  .util-link { @apply inline-flex items-center gap-1.5 text-sm font-medium text-gray-300 transition-colors hover:text-white; }
+  .mega-link { @apply flex items-start gap-3 p-3 transition-colors hover:bg-cream; }
+
+  /* ---- Misc ---- */
+  .divider { @apply h-px w-full bg-line; }
+  .overlay-grad { @apply absolute inset-0 bg-gradient-to-r from-ink/85 via-ink/65 to-ink/20; }
+  .overlay-grad-b { @apply absolute inset-0 bg-gradient-to-t from-ink/85 via-ink/40 to-transparent; }
+
+  /* ---- Prose for CMS markdown ---- */
+  .prose-mibox {
+    @apply prose max-w-none prose-headings:text-dark prose-headings:font-bold
+           prose-p:text-secondary prose-li:text-secondary
+           prose-a:font-semibold prose-a:text-dark prose-strong:text-dark
+           prose-blockquote:border-l-4 prose-blockquote:border-l-primary
+           prose-blockquote:bg-cream prose-blockquote:py-1 prose-blockquote:text-dark prose-blockquote:not-italic;
+  }
+}
+
+.date-time-field #delivery-date { width: 100% !important; padding: 0.75rem !important; }
+html { scroll-behavior: smooth; }


### PR DESCRIPTION
Port the miboxfirstcoast design system to eli-containers for a consistent, industrial, balanced look across all components.

- global.css: full MI-BOX design system (yellow #FFC20E + charcoal/ink), zero border-radius theme tokens (squares every rounded-* utility), and shared component classes (btn, card, eyebrow, headings, nav, forms, badges, overlays, prose-mibox).
- Chrome: white industrial Header w/ amber-hover nav + yellow phone CTA, MI-BOX yellow Topbar, dark ink Footer.
- Sections/heroes/forms/ui restyled to the system: dark ink hero scrims (replacing blue gradients), square cards, yellow accents always on dark text, prose-mibox for CMS markdown.
- Replaced legacy blue brand (#009ad6/#0069e5) throughout.

Data bindings, CMS field access, and slider/accordion/Turnstile scripts preserved. Dead components (CustomNav, ProtectionConvenience, StorageOptions) left untouched. Build passes.